### PR TITLE
Add `-parameters` compile option to support Spring Boot 3.2 (Spring 6.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.10.1</version>
+                    <configuration>
+                        <parameters>true</parameters>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
In Spring Boot 3.2 (Spring 6.1) `LocalVariableTableParameterNameDiscoverer` was removed, so to get the parameter name from DTO classes (e.g. TaskRequestParams and TaskDetailsRequestParams in TaskController methods) you have to compile it with `-parameter`. 

Refer to: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes#parameter-name-discovery
