### PR TITLE
Fix serialization issues for rescheduling tasks.

### DIFF
--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -61,8 +61,10 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  TaskLogic taskLogic(Scheduler scheduler, Caching caching, DbSchedulerUiProperties properties) {
-    return new TaskLogic(scheduler, caching, properties.isTaskData());
+  TaskLogic taskLogic(Scheduler scheduler, DbSchedulerCustomizer customizer, Caching caching,
+      DbSchedulerUiProperties properties) {
+    return new TaskLogic(scheduler, customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
+        caching, properties.isTaskData());
   }
 
   @Bean

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/TaskModel.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/TaskModel.java
@@ -13,12 +13,17 @@
  */
 package no.bekk.dbscheduler.ui.model;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.List;
-import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
 public class TaskModel {
   private String taskName;
   private List<String> taskInstance;
@@ -31,127 +36,4 @@ public class TaskModel {
   private List<Integer> consecutiveFailures;
   private Instant lastHeartbeat;
   private int version;
-
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
-  public TaskModel(
-      String taskName,
-      List<String> taskInstance,
-      List<Object> inputTaskData,
-      List<Instant> executionTime,
-      List<Boolean> picked,
-      List<String> pickedBy,
-      List<Instant> lastSuccess,
-      Instant lastFailure,
-      List<Integer> consecutiveFailures,
-      Instant lastHeartbeat,
-      int version) {
-    this.taskName = taskName;
-    this.taskInstance = taskInstance;
-    this.taskData = serializeTaskData(inputTaskData);
-    this.executionTime = executionTime;
-    this.picked = picked;
-    this.pickedBy = pickedBy;
-    this.lastSuccess = lastSuccess;
-    this.lastFailure = lastFailure;
-    this.consecutiveFailures = consecutiveFailures;
-    this.lastHeartbeat = lastHeartbeat;
-    this.version = version;
-  }
-
-  public TaskModel() {}
-
-  private List<Object> serializeTaskData(List<Object> inputTaskDataList) {
-    return inputTaskDataList.stream()
-        .map(
-            data -> {
-              try {
-                String serializedData = objectMapper.writeValueAsString(data);
-                return objectMapper.readValue(serializedData, Object.class);
-              } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-              }
-            })
-        .collect(Collectors.toList());
-  }
-
-  public String getTaskName() {
-    return taskName;
-  }
-
-  public List<String> getTaskInstance() {
-    return taskInstance;
-  }
-
-  public void setTaskInstance(List<String> taskInstance) {
-    this.taskInstance = taskInstance;
-  }
-
-  public List<Object> getTaskData() {
-    return taskData;
-  }
-
-  public void setTaskData(List<Object> inputTaskData) {
-    this.taskData = serializeTaskData(inputTaskData);
-  }
-
-  public void setExecutionTime(List<Instant> executionTime) {
-    this.executionTime = executionTime;
-  }
-
-  public List<Instant> getExecutionTime() {
-    return executionTime;
-  }
-
-  public List<Boolean> isPicked() {
-    return picked;
-  }
-
-  public void setPicked(List<Boolean> picked) {
-    this.picked = picked;
-  }
-
-  public List<String> getPickedBy() {
-    return pickedBy;
-  }
-
-  public void setPickedBy(List<String> pickedBy) {
-    this.pickedBy = pickedBy;
-  }
-
-  public List<Instant> getLastSuccess() {
-    return lastSuccess;
-  }
-
-  public void setLastSuccess(List<Instant> lastSuccess) {
-    this.lastSuccess = lastSuccess;
-  }
-
-  public Instant getLastFailure() {
-    return lastFailure;
-  }
-
-  public void setLastFailure(Instant lastFailure) {
-    this.lastFailure = lastFailure;
-  }
-
-  public List<Integer> getConsecutiveFailures() {
-    return consecutiveFailures;
-  }
-
-  public Instant getLastHeartbeat() {
-    return lastHeartbeat;
-  }
-
-  public void setLastHeartbeat(Instant lastHeartbeat) {
-    this.lastHeartbeat = lastHeartbeat;
-  }
-
-  public int getVersion() {
-    return version;
-  }
-
-  public void setConsecutiveFailures(List<Integer> consecutiveFailures) {
-    this.consecutiveFailures = consecutiveFailures;
-  }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/util/QueryUtils.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/util/QueryUtils.java
@@ -44,12 +44,12 @@ public class QueryUtils {
                 case FAILED:
                   return task.getConsecutiveFailures().stream().anyMatch(failures -> failures != 0);
                 case RUNNING:
-                  return task.isPicked().stream().anyMatch(Boolean::booleanValue);
+                  return task.getPicked().stream().anyMatch(Boolean::booleanValue);
                 case SCHEDULED:
-                  return IntStream.range(0, task.isPicked().size())
+                  return IntStream.range(0, task.getPicked().size())
                       .anyMatch(
                           i ->
-                              !task.isPicked().get(i) && task.getConsecutiveFailures().get(i) == 0);
+                              !task.getPicked().get(i) && task.getConsecutiveFailures().get(i) == 0);
                 default:
                   return true;
               }

--- a/example-app/src/main/java/com/github/bekk/exampleapp/model/TaskScheduleAndNoData.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/model/TaskScheduleAndNoData.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bekk.exampleapp.model;
+
+import com.github.kagkarlsson.scheduler.task.helper.ScheduleAndData;
+import com.github.kagkarlsson.scheduler.task.schedule.CronSchedule;
+import java.io.Serializable;
+
+public class TaskScheduleAndNoData implements ScheduleAndData, Serializable {
+
+  private static final long serialVersionUID = 1L; // recommended when using Java serialization
+
+  private final CronSchedule schedule;
+
+  private TaskScheduleAndNoData() {
+    this(null);
+  }
+
+  public TaskScheduleAndNoData(CronSchedule schedule) {
+    this.schedule = schedule;
+  }
+
+  @Override
+  public CronSchedule getSchedule() {
+    return this.schedule;
+  }
+
+  @Override
+  public Object getData() {
+    return null;
+  }
+}

--- a/example-app/src/main/java/com/github/bekk/exampleapp/tasks/DynamicRecurringTaskExample.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/tasks/DynamicRecurringTaskExample.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bekk.exampleapp.tasks;
+
+import com.github.bekk.exampleapp.model.TaskScheduleAndNoData;
+import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTaskWithPersistentSchedule;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import utils.Utils;
+
+@Configuration
+public class DynamicRecurringTaskExample {
+
+  public static final TaskWithDataDescriptor<TaskScheduleAndNoData> DYNAMIC_RECURRING_TASK =
+      new TaskWithDataDescriptor<>("dynamic-recurring-task", TaskScheduleAndNoData.class);
+
+  @Bean
+  public RecurringTaskWithPersistentSchedule<TaskScheduleAndNoData> runDynamicRecurringTask() {
+    return Tasks.recurringWithPersistentSchedule(DYNAMIC_RECURRING_TASK).execute((inst, ctx) -> {
+      Utils.sleep(500);
+      System.out.println("Executed dynamic recurring task: " + inst.getTaskName());
+    });
+  }
+}

--- a/example-app/src/test/java/com/github/bekk/exampleapp/DynamicRecurringSchedulingTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/DynamicRecurringSchedulingTest.java
@@ -1,0 +1,74 @@
+package com.github.bekk.exampleapp;
+
+import static com.github.bekk.exampleapp.tasks.DynamicRecurringTaskExample.DYNAMIC_RECURRING_TASK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.bekk.exampleapp.model.TaskScheduleAndNoData;
+import com.github.kagkarlsson.scheduler.SchedulerClient;
+import com.github.kagkarlsson.scheduler.task.schedule.CronSchedule;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
+import java.time.Instant;
+import no.bekk.dbscheduler.ui.controller.TaskController;
+import no.bekk.dbscheduler.ui.model.GetTasksResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+    classes = {ExampleApp.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class DynamicRecurringSchedulingTest {
+
+  @LocalServerPort
+  private Integer serverPort;
+
+  private String baseUrl;
+
+  @Autowired
+  TaskController controller;
+
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @Autowired
+  private SchedulerClient schedulerClient;
+
+  @Test
+  public void testGetTasksReturnsDynamicRecurringTask()  {
+    // Given
+    CronSchedule cron = Schedules.cron("0 0/1 * * * *"); // every minute
+    TaskScheduleAndNoData data = new TaskScheduleAndNoData(cron);
+
+    schedulerClient.schedule(
+        DYNAMIC_RECURRING_TASK.instance("single_instance", data),
+        cron.getInitialExecutionTime(Instant.now()));
+
+    // When
+    ResponseEntity<GetTasksResponse> result =
+        this.restTemplate.getForEntity(
+            baseUrl
+                + "/db-scheduler-api/tasks/all?filter=ALL&pageNumber=0&size=10&sorting=DEFAULT&asc=true&searchTerm="
+                + DYNAMIC_RECURRING_TASK.getTaskName(),
+            GetTasksResponse.class);
+
+    // Then
+    Assertions.assertEquals(result.getStatusCode(), HttpStatus.OK);
+    result.getBody().getItems().forEach(t -> System.out.println(t.getTaskName()));
+    assertThat(result.getBody().getItems())
+        .anyMatch(taskModel -> taskModel.getTaskName().equals(DYNAMIC_RECURRING_TASK.getTaskName()));
+  }
+
+  @BeforeEach
+  public void setUp() {
+    baseUrl = "http://localhost:" + serverPort;
+  }
+}


### PR DESCRIPTION
Fix exception when it trying to save task with schedule then Exception is throwing:
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.ZoneRegion` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: com.github.bekk.exampleapp.model.TaskScheduleAndNoData["schedule"]->com.github.kagkarlsson.scheduler.task.schedule.CronSchedule["zoneId"])] with root cause.
Please see `DynamicRecurringSchedulingTest.java`