### PR TITLE
Sort logs by ID instead of task_finished. Add customizable limit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # DB Scheduler UI
+
 ![build status](https://github.com/bekk/db-scheduler-ui/workflows/Build/badge.svg)
 [![License](http://img.shields.io/:license-apache-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
-
-A UI extension for [db-scheduler](https://github.com/kagkarlsson/db-scheduler) that provides a browser accessible 
+A UI extension for [db-scheduler](https://github.com/kagkarlsson/db-scheduler) that provides a browser accessible
 dashboard for monitoring and basic administration of tasks.
-
 
 ## Features
 
@@ -33,10 +32,12 @@ dashboard for monitoring and basic administration of tasks.
 * Minimum Java 11 and SpringBoot 2.7
 * Optional (if you want task history): db-scheduler-log version 0.7.0
 
-
 ## Getting started
+
 1. Add the db-scheduler-ui spring boot starter maven dependency
+
 ```xml
+
 <dependency>
     <groupId>no.bekk.db-scheduler-ui</groupId>
     <artifactId>db-scheduler-ui-starter</artifactId>
@@ -44,68 +45,78 @@ dashboard for monitoring and basic administration of tasks.
 </dependency>
 ```
 
-2. Read the [db-scheduler](https://github.com/kagkarlsson/db-scheduler) readme and follow the getting started guide. The most important is to create the `scheduled_tasks` table correctly.
+2. Read the [db-scheduler](https://github.com/kagkarlsson/db-scheduler) readme and follow the getting started guide. The
+   most important is to create the `scheduled_tasks` table correctly.
    You do not need to add db-scheduler as a dependency.
 3. Start your application. The db-scheduler UI can be reached at `<your-app-url>/db-scheduler`
 
-
 ## Optional: task history
+
 If you want to add task history to your UI you need to add the following dependency:
+
 ```xml
+
 <dependency>
     <groupId>io.rocketbase.extension</groupId>
     <artifactId>db-scheduler-log-spring-boot-starter</artifactId>
     <version>0.7.0</version>
 </dependency>
 ```
+
 Follow the [readme](https://github.com/rocketbase-io/db-scheduler-log) to create the correct database table.
 
-You also need to set `db-scheduler-ui.history=true` in your application.properties file.
-
+You also need to set `db-scheduler-ui.history=true` in your application.properties file, and consider setting a limit to
+the number of logs fetched: `db-scheduler-ui.log-limit=1000`.
 
 ## How it works
-db-scheduler-ui adds a REST-api package that has a bundled frontend application. 
+
+db-scheduler-ui adds a REST-api package that has a bundled frontend application.
 Springboot is used to configure beans and handle dependencies within the library and your application.
-The user interface makes calls to the scheduler-client, where it can fetch, delete, run, and reschedule tasks. 
-These tasks are then shown in the web application. 
-An optional log module can also be added, making it possible to view the history of all your task executions. 
+The user interface makes calls to the scheduler-client, where it can fetch, delete, run, and reschedule tasks.
+These tasks are then shown in the web application.
+An optional log module can also be added, making it possible to view the history of all your task executions.
 
 ## Configuration
 
-db-scheduler-ui can be configured using the following options: <br>
+db-scheduler-ui can be configured using the following options:
 
-Turns on db-scheduler-log, default value is false. See [Optional: task history](#optional-task-history)
-```
-db-scheduler-ui.history=false
-```
-<br>
-If you for some reason want to hide the task data you can set this to false. defaults to true
+`history`: Turns on db-scheduler-log, default value is `false`. You can also limit the number of logs to fetch
+with `log-limit`.
 
 ```
-db-scheduler-ui.task-data=true
+db-scheduler-ui.history=true
+db-scheduler-ui.log-limit=1000
 ```
 
+If you for some reason want to hide the task data you can set this to false. defaults to `true`
 
+```
+db-scheduler-ui.task-data=false
+```
 
 ## Contributing
 
-Feel free to create pull requests if there are features or improvements you want to add. 
-PR's need to be approved by one of the maintainers. To publish a new version, create a release in Github and tag it with a SemVer version.
+Feel free to create pull requests if there are features or improvements you want to add.
+PR's need to be approved by one of the maintainers. To publish a new version, create a release in Github and tag it with
+a SemVer version.
 A new release will then be released to maven central by a github action using JReleaser.
 
 Before submitting a PR make sure to run `mvn spotless:apply` to format the code correctly.
 Please use the prettier config when making frontend changes
 
-
 ## Local development
+
 Prerequisites:
+
 * Maven
 * JDK11
 * Node
 * npm
 
 There are two ways to run the frontend locally.
+
 1. running `npm run dev` inside the db-scheduler-ui-frontend folder
-2. running `mvn install` will build the frontend and copy the output to the resources folder in the `db-scheduler-ui` module. The frontend will then be available at the same port as the example app.
+2. running `mvn install` will build the frontend and copy the output to the resources folder in the `db-scheduler-ui`
+   module. The frontend will then be available at the same port as the example app.
 
 To run the backend run `mvn clean install` and then run the example app.

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -77,13 +77,15 @@ public class UiApiAutoConfiguration {
       Caching caching,
       DbSchedulerCustomizer customizer,
       DbSchedulerUiProperties properties,
-      @Value("${db-scheduler-log.table-name:scheduled_execution_logs}") String logTableName) {
+      @Value("${db-scheduler-log.table-name:scheduled_execution_logs}") String logTableName,
+      @Value("${db-scheduler-ui.log-limit:0}") int logLimit) {
     return new LogLogic(
         dataSource,
         customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
         caching,
         properties.isTaskData(),
-        logTableName);
+        logTableName,
+        logLimit);
   }
 
   @Bean

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
@@ -21,7 +21,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Getter
 @ConfigurationProperties("db-scheduler-ui")
 public class DbSchedulerUiProperties {
+
   private boolean enabled = true;
   private boolean taskData = true;
   private boolean history = false;
+  private int logLimit = 0;
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/GetLogsResponse.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/GetLogsResponse.java
@@ -16,8 +16,11 @@ package no.bekk.dbscheduler.ui.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public class GetLogsResponse {
+
   private final int numberOfItems;
   private final int numberOfPages;
   private final List<LogModel> items;
@@ -30,17 +33,5 @@ public class GetLogsResponse {
     this.numberOfItems = totalLogs;
     this.numberOfPages = totalLogs == 0 ? 0 : (int) Math.ceil((double) totalLogs / pageSize);
     this.items = pagedLogs;
-  }
-
-  public int getNumberOfItems() {
-    return numberOfItems;
-  }
-
-  public int getNumberOfPages() {
-    return numberOfPages;
-  }
-
-  public List<LogModel> getItems() {
-    return items;
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/GetTasksResponse.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/GetTasksResponse.java
@@ -16,8 +16,11 @@ package no.bekk.dbscheduler.ui.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public class GetTasksResponse {
+
   private final int numberOfItems;
   private final int numberOfPages;
   private final List<TaskModel> items;
@@ -30,17 +33,5 @@ public class GetTasksResponse {
     this.numberOfItems = totalTasks;
     this.numberOfPages = totalTasks == 0 ? 0 : (int) Math.ceil((double) totalTasks / pageSize);
     this.items = pagedTasks;
-  }
-
-  public int getNumberOfItems() {
-    return numberOfItems;
-  }
-
-  public int getNumberOfPages() {
-    return numberOfPages;
-  }
-
-  public List<TaskModel> getItems() {
-    return items;
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/LogPollResponse.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/LogPollResponse.java
@@ -13,21 +13,16 @@
  */
 package no.bekk.dbscheduler.ui.model;
 
+import lombok.Getter;
+
+@Getter
 public class LogPollResponse {
+
+  private final int newFailures;
+  private final int newSucceeded;
+
   public LogPollResponse(int newFailures, int newSucceeded) {
     this.newFailures = newFailures;
     this.newSucceeded = newSucceeded;
   }
-
-  private final int newFailures;
-
-  public int getNewFailures() {
-    return newFailures;
-  }
-
-  public int getNewSucceeded() {
-    return newSucceeded;
-  }
-
-  private final int newSucceeded;
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/PollResponse.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/PollResponse.java
@@ -13,7 +13,11 @@
  */
 package no.bekk.dbscheduler.ui.model;
 
+import lombok.Getter;
+
+@Getter
 public class PollResponse {
+
   private final int newFailures;
   private final int newRunning;
   private final int newTasks;
@@ -27,25 +31,5 @@ public class PollResponse {
     this.newTasks = newTasks;
     this.stoppedFailing = stoppedFailing;
     this.finishedRunning = finishedRunning;
-  }
-
-  public int getNewFailures() {
-    return newFailures;
-  }
-
-  public int getNewRunning() {
-    return newRunning;
-  }
-
-  public int getNewTasks() {
-    return newTasks;
-  }
-
-  public int getStoppedFailing() {
-    return stoppedFailing;
-  }
-
-  public int getFinishedRunning() {
-    return finishedRunning;
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/TaskDetailsRequestParams.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/TaskDetailsRequestParams.java
@@ -14,7 +14,9 @@
 package no.bekk.dbscheduler.ui.model;
 
 import java.time.Instant;
+import lombok.Getter;
 
+@Getter
 public class TaskDetailsRequestParams extends TaskRequestParams {
 
   private final String taskId;
@@ -50,13 +52,5 @@ public class TaskDetailsRequestParams extends TaskRequestParams {
         refresh);
     this.taskId = taskId;
     this.taskName = taskName;
-  }
-
-  public String getTaskId() {
-    return taskId;
-  }
-
-  public String getTaskName() {
-    return taskName;
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/TaskRequestParams.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/TaskRequestParams.java
@@ -14,8 +14,9 @@
 package no.bekk.dbscheduler.ui.model;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import lombok.Getter;
 
+@Getter
 public class TaskRequestParams {
 
   private final TaskFilter filter;
@@ -23,16 +24,13 @@ public class TaskRequestParams {
   private final int size;
   private final TaskSort sorting;
   private final boolean asc;
-  private boolean refresh;
   private final String searchTermTaskName;
-
   private final String searchTermTaskInstance;
-
   private final boolean taskNameExactMatch;
-
   private final boolean taskInstanceExactMatch;
   private final Instant startTime;
   private final Instant endTime;
+  private final boolean refresh;
 
   public TaskRequestParams(
       TaskFilter filter,
@@ -56,61 +54,9 @@ public class TaskRequestParams {
     this.searchTermTaskInstance = searchTermTaskInstance;
     this.taskNameExactMatch = taskNameExactMatch != null ? taskNameExactMatch : false;
     this.taskInstanceExactMatch = taskInstanceExactMatch != null ? taskInstanceExactMatch : false;
-    this.startTime = startTime != null ? startTime : Instant.now().minus(50, ChronoUnit.DAYS);
-    this.endTime = endTime != null ? endTime : Instant.now().plus(50, ChronoUnit.DAYS);
+    this.startTime = startTime;
+    this.endTime = endTime;
     this.refresh = refresh != null ? refresh : true;
-  }
-
-  public TaskFilter getFilter() {
-    return filter;
-  }
-
-  public int getPageNumber() {
-    return pageNumber;
-  }
-
-  public int getSize() {
-    return size;
-  }
-
-  public TaskSort getSorting() {
-    return sorting;
-  }
-
-  public boolean isAsc() {
-    return asc;
-  }
-
-  public boolean isRefresh() {
-    return refresh;
-  }
-
-  public String getSearchTermTaskName() {
-    return searchTermTaskName;
-  }
-
-  public String getSearchTermTaskInstance() {
-    return searchTermTaskInstance;
-  }
-
-  public boolean isTaskNameExactMatch() {
-    return taskNameExactMatch;
-  }
-
-  public boolean isTaskInstanceExactMatch() {
-    return taskInstanceExactMatch;
-  }
-
-  public void setRefresh(boolean refresh) {
-    this.refresh = refresh;
-  }
-
-  public Instant getStartTime() {
-    return startTime;
-  }
-
-  public Instant getEndTime() {
-    return endTime;
   }
 
   public enum TaskFilter {


### PR DESCRIPTION
When the log table grows to millions of logs, the current strategy of fetching (and caching) all logs becomes untenable.

By adding an optional limit, users can configure a cutoff for how many logs should be fetched.

Note that the cache might still grow very large, this is not addressed in this PR.

Also, the sorting can be optimized by sorting by ID instead of `task_finished`, as the ID is a [snowflake](https://en.wikipedia.org/wiki/Snowflake_ID) with the exact same order as `task_finished`, but can use the PK index.