### PR TITLE
Spring Boot 3 upgrade

### DIFF
--- a/db-scheduler-ui-starter/pom.xml
+++ b/db-scheduler-ui-starter/pom.xml
@@ -15,6 +15,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.github.kagkarlsson</groupId>
             <artifactId>db-scheduler-spring-boot-starter</artifactId>
         </dependency>

--- a/example-app-webflux/src/main/java/com/github/bekk/exampleapp/service/TaskService.java
+++ b/example-app-webflux/src/main/java/com/github/bekk/exampleapp/service/TaskService.java
@@ -35,13 +35,14 @@ public class TaskService {
 
   public void runManuallyTriggeredTasks() {
     scheduler.schedule(
-        ONE_TIME_TASK.instance("1", new TaskData(1, "test data", Instant.now())), Instant.now());
-
-    scheduler.schedule(
-        CHAINED_STEP_1_TASK.instance("3", new TestObject("Ole Nordman", 1, "ole.nordman@mail.com")),
+        ONE_TIME_TASK.instance("1").data(new TaskData(1, "test data", Instant.now())).build(),
         Instant.now());
 
-    scheduler.schedule(LONG_RUNNING_ONETIME_TASK.instance("5"), Instant.now().plusSeconds(2));
-    scheduler.schedule(FAILING_ONETIME_TASK.instance("6"), Instant.now().plusSeconds(2));
+    scheduler.schedule(
+        CHAINED_STEP_1_TASK.instance("3").data(new TestObject("Ole Nordman", 1, "ole.nordman@mail.com")).build(),
+        Instant.now());
+
+    scheduler.schedule(LONG_RUNNING_ONETIME_TASK.instance("5").build(), Instant.now().plusSeconds(2));
+    scheduler.schedule(FAILING_ONETIME_TASK.instance("6").build(), Instant.now().plusSeconds(2));
   }
 }

--- a/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/ChainTask.java
+++ b/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/ChainTask.java
@@ -18,7 +18,7 @@ import static utils.Utils.sleep;
 import com.github.bekk.exampleapp.model.TestObject;
 import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import java.time.Instant;
 import org.springframework.context.annotation.Bean;
@@ -27,11 +27,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ChainTask {
 
-  public static final TaskWithDataDescriptor<TestObject> CHAINED_STEP_1_TASK =
-      new TaskWithDataDescriptor<>("chained-step-1", TestObject.class);
+  public static final TaskDescriptor<TestObject> CHAINED_STEP_1_TASK =
+      TaskDescriptor.of("chained-step-1", TestObject.class);
 
-  public static final TaskWithDataDescriptor<TestObject> CHAINED_STEP_2_TASK =
-      new TaskWithDataDescriptor<>("chained-step-2", TestObject.class);
+  public static final TaskDescriptor<TestObject> CHAINED_STEP_2_TASK =
+      TaskDescriptor.of("chained-step-2", TestObject.class);
 
   @Bean
   public Task<TestObject> chainTaskStepOne() {
@@ -47,8 +47,9 @@ public class ChainTask {
                       + inst.getId());
               TestObject data = inst.getData();
               data.setId(data.getId() + 1);
-              client.schedule(
-                  CHAINED_STEP_2_TASK.instance(inst.getId(), data), Instant.now().plusSeconds(10));
+              client.scheduleIfNotExists(
+                  CHAINED_STEP_2_TASK.instance(inst.getId()).data(data).build(),
+                  Instant.now().plusSeconds(10));
             });
   }
 
@@ -66,8 +67,9 @@ public class ChainTask {
                       + inst.getId());
               TestObject data = inst.getData();
               data.setId(data.getId() + 1);
-              client.schedule(
-                  CHAINED_STEP_1_TASK.instance(inst.getId(), data), Instant.now().plusSeconds(20));
+              client.scheduleIfNotExists(
+                  CHAINED_STEP_1_TASK.instance(inst.getId()).data( data).build(),
+                  Instant.now().plusSeconds(20));
             });
   }
 }

--- a/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/FailingTask.java
+++ b/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/FailingTask.java
@@ -17,7 +17,7 @@ import static java.time.Duration.ofSeconds;
 
 import com.github.kagkarlsson.scheduler.task.FailureHandler;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithoutDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import org.springframework.context.annotation.Bean;
@@ -26,14 +26,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class FailingTask {
 
-  public static final TaskWithoutDataDescriptor FAILING_ONETIME_TASK =
-      new TaskWithoutDataDescriptor("failing-one-time-task");
+  public static final TaskDescriptor<Void> FAILING_ONETIME_TASK =
+      TaskDescriptor.of("failing-one-time-task");
 
-  public static final TaskWithoutDataDescriptor FAILING_RECURRING_TASK =
-      new TaskWithoutDataDescriptor("failing-recurring-task");
+  public static final TaskDescriptor<Void> FAILING_RECURRING_TASK =
+      TaskDescriptor.of("failing-recurring-task");
 
-  public static final TaskWithoutDataDescriptor FAILING_ONETIME_TASK_BACKOFF =
-      new TaskWithoutDataDescriptor("failing-one-time-with-backoff-task");
+  public static final TaskDescriptor<Void> FAILING_ONETIME_TASK_BACKOFF =
+      TaskDescriptor.of("failing-one-time-with-backoff-task");
 
   @Bean
   public Task<?> runOneTimeFailing() {

--- a/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/LongRunningTask.java
+++ b/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/LongRunningTask.java
@@ -16,7 +16,7 @@ package com.github.bekk.exampleapp.tasks;
 import static utils.Utils.sleep;
 
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithoutDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import org.springframework.context.annotation.Bean;
@@ -25,11 +25,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class LongRunningTask {
 
-  public static final TaskWithoutDataDescriptor LONG_RUNNING_ONETIME_TASK =
-      new TaskWithoutDataDescriptor("long-running-task");
+  public static final TaskDescriptor<Void> LONG_RUNNING_ONETIME_TASK =
+      TaskDescriptor.of("long-running-task");
 
-  public static final TaskWithoutDataDescriptor LONG_RUNNING_RECURRING_TASK =
-      new TaskWithoutDataDescriptor("long-running-recurring-task");
+  public static final TaskDescriptor<Void> LONG_RUNNING_RECURRING_TASK =
+      TaskDescriptor.of("long-running-recurring-task");
 
   @Bean
   public Task<?> runLongRunningTask() {

--- a/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/OneTimeTaskExample.java
+++ b/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/OneTimeTaskExample.java
@@ -15,7 +15,7 @@ package com.github.bekk.exampleapp.tasks;
 
 import com.github.bekk.exampleapp.model.TaskData;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,8 +23,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OneTimeTaskExample {
 
-  public static final TaskWithDataDescriptor<TaskData> ONE_TIME_TASK =
-      new TaskWithDataDescriptor<>("onetime-task", TaskData.class);
+  public static final TaskDescriptor<TaskData> ONE_TIME_TASK =
+      TaskDescriptor.of("onetime-task", TaskData.class);
 
   @Bean
   public Task<TaskData> exampleOneTimeTask() {

--- a/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/RecurringTaskExample.java
+++ b/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/RecurringTaskExample.java
@@ -15,7 +15,7 @@ package com.github.bekk.exampleapp.tasks;
 
 import static utils.Utils.sleep;
 
-import com.github.kagkarlsson.scheduler.task.TaskWithoutDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
@@ -26,8 +26,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RecurringTaskExample {
 
-  public static final TaskWithoutDataDescriptor RECURRING_TASK =
-      new TaskWithoutDataDescriptor("recurring-task");
+  public static final TaskDescriptor<Void> RECURRING_TASK =
+      TaskDescriptor.of("recurring-task");
 
   @Bean
   public RecurringTask<Void> getExample() {

--- a/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/SpawnerTask.java
+++ b/example-app-webflux/src/main/java/com/github/bekk/exampleapp/tasks/SpawnerTask.java
@@ -18,8 +18,7 @@ import static utils.Utils.sleep;
 import com.github.bekk.exampleapp.model.TaskData;
 import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
-import com.github.kagkarlsson.scheduler.task.TaskWithoutDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import java.time.Instant;
@@ -31,11 +30,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SpawnerTask {
 
-  public static final TaskWithoutDataDescriptor RECURRING_SPAWNER_TASK =
-      new TaskWithoutDataDescriptor("recurring-spawner-task");
+  public static final TaskDescriptor<Void> RECURRING_SPAWNER_TASK =
+      TaskDescriptor.of("recurring-spawner-task");
 
-  public static final TaskWithDataDescriptor<TaskData> ONE_TIME_SPAWNER_TASK =
-      new TaskWithDataDescriptor<>("onetime-spawned-task", TaskData.class);
+  public static final TaskDescriptor<TaskData> ONE_TIME_SPAWNER_TASK =
+      TaskDescriptor.of("onetime-spawned-task", TaskData.class);
 
   @Bean
   public Task<?> runSpawner() {
@@ -46,10 +45,11 @@ public class SpawnerTask {
               final long randomUUID = UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
 
               for (int i = 0; i < 100; i++) {
-                client.schedule(
-                    ONE_TIME_SPAWNER_TASK.instance(
-                        "spawned " + randomUUID + " loopnr: " + i,
-                        new TaskData(123, "{data: MASSIVEDATA}", Instant.now())),
+                client.scheduleIfNotExists(
+                    ONE_TIME_SPAWNER_TASK
+                        .instance("spawned " + randomUUID + " loopnr: " + i)
+                        .data(new TaskData(123, "{data: MASSIVEDATA}", Instant.now()))
+                        .build(),
                     Instant.now().plusSeconds(60));
               }
             });

--- a/example-app/src/main/java/com/github/bekk/exampleapp/service/TaskService.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/service/TaskService.java
@@ -35,13 +35,14 @@ public class TaskService {
 
   public void runManuallyTriggeredTasks() {
     scheduler.schedule(
-        ONE_TIME_TASK.instance("1", new TaskData(1, "test data", Instant.now())), Instant.now());
-
-    scheduler.schedule(
-        CHAINED_STEP_1_TASK.instance("3", new TestObject("Ole Nordman", 1, "ole.nordman@mail.com")),
+        ONE_TIME_TASK.instance("1").data( new TaskData(1, "test data", Instant.now())).build(),
         Instant.now());
 
-    scheduler.schedule(LONG_RUNNING_ONETIME_TASK.instance("5"), Instant.now().plusSeconds(2));
-    scheduler.schedule(FAILING_ONETIME_TASK.instance("6"), Instant.now().plusSeconds(2));
+    scheduler.schedule(
+        CHAINED_STEP_1_TASK.instance("3").data(new TestObject("Ole Nordman", 1, "ole.nordman@mail.com")).build(),
+        Instant.now());
+
+    scheduler.schedule(LONG_RUNNING_ONETIME_TASK.instance("5").build(), Instant.now().plusSeconds(2));
+    scheduler.schedule(FAILING_ONETIME_TASK.instance("6").build(), Instant.now().plusSeconds(2));
   }
 }

--- a/example-app/src/main/java/com/github/bekk/exampleapp/tasks/ChainTask.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/tasks/ChainTask.java
@@ -18,7 +18,7 @@ import static utils.Utils.sleep;
 import com.github.bekk.exampleapp.model.TestObject;
 import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import java.time.Instant;
 import org.springframework.context.annotation.Bean;
@@ -27,11 +27,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ChainTask {
 
-  public static final TaskWithDataDescriptor<TestObject> CHAINED_STEP_1_TASK =
-      new TaskWithDataDescriptor<>("chained-step-1", TestObject.class);
+  public static final TaskDescriptor<TestObject> CHAINED_STEP_1_TASK =
+      TaskDescriptor.of("chained-step-1", TestObject.class);
 
-  public static final TaskWithDataDescriptor<TestObject> CHAINED_STEP_2_TASK =
-      new TaskWithDataDescriptor<>("chained-step-2", TestObject.class);
+  public static final TaskDescriptor<TestObject> CHAINED_STEP_2_TASK =
+      TaskDescriptor.of("chained-step-2", TestObject.class);
 
   @Bean
   public Task<TestObject> chainTaskStepOne() {
@@ -47,8 +47,9 @@ public class ChainTask {
                       + inst.getId());
               TestObject data = inst.getData();
               data.setId(data.getId() + 1);
-              client.schedule(
-                  CHAINED_STEP_2_TASK.instance(inst.getId(), data), Instant.now().plusSeconds(10));
+              client.scheduleIfNotExists(
+                  CHAINED_STEP_2_TASK.instance(inst.getId()).data( data).build(),
+                  Instant.now().plusSeconds(10));
             });
   }
 
@@ -66,8 +67,9 @@ public class ChainTask {
                       + inst.getId());
               TestObject data = inst.getData();
               data.setId(data.getId() + 1);
-              client.schedule(
-                  CHAINED_STEP_1_TASK.instance(inst.getId(), data), Instant.now().plusSeconds(20));
+              client.scheduleIfNotExists(
+                  CHAINED_STEP_1_TASK.instance(inst.getId()).data( data).build(),
+                  Instant.now().plusSeconds(20));
             });
   }
 }

--- a/example-app/src/main/java/com/github/bekk/exampleapp/tasks/DynamicRecurringTaskExample.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/tasks/DynamicRecurringTaskExample.java
@@ -14,7 +14,7 @@
 package com.github.bekk.exampleapp.tasks;
 
 import com.github.bekk.exampleapp.model.TaskScheduleAndNoData;
-import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.RecurringTaskWithPersistentSchedule;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import org.springframework.context.annotation.Bean;
@@ -24,8 +24,8 @@ import utils.Utils;
 @Configuration
 public class DynamicRecurringTaskExample {
 
-  public static final TaskWithDataDescriptor<TaskScheduleAndNoData> DYNAMIC_RECURRING_TASK =
-      new TaskWithDataDescriptor<>("dynamic-recurring-task", TaskScheduleAndNoData.class);
+  public static final TaskDescriptor<TaskScheduleAndNoData> DYNAMIC_RECURRING_TASK =
+      TaskDescriptor.of("dynamic-recurring-task", TaskScheduleAndNoData.class);
 
   @Bean
   public RecurringTaskWithPersistentSchedule<TaskScheduleAndNoData> runDynamicRecurringTask() {

--- a/example-app/src/main/java/com/github/bekk/exampleapp/tasks/FailingTask.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/tasks/FailingTask.java
@@ -17,7 +17,7 @@ import static java.time.Duration.ofSeconds;
 
 import com.github.kagkarlsson.scheduler.task.FailureHandler;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithoutDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import org.springframework.context.annotation.Bean;
@@ -26,14 +26,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class FailingTask {
 
-  public static final TaskWithoutDataDescriptor FAILING_ONETIME_TASK =
-      new TaskWithoutDataDescriptor("failing-one-time-task");
+  public static final TaskDescriptor<Void> FAILING_ONETIME_TASK =
+      TaskDescriptor.of("failing-one-time-task");
 
-  public static final TaskWithoutDataDescriptor FAILING_RECURRING_TASK =
-      new TaskWithoutDataDescriptor("failing-recurring-task");
+  public static final TaskDescriptor<Void> FAILING_RECURRING_TASK =
+      TaskDescriptor.of("failing-recurring-task");
 
-  public static final TaskWithoutDataDescriptor FAILING_ONETIME_TASK_BACKOFF =
-      new TaskWithoutDataDescriptor("failing-one-time-with-backoff-task");
+  public static final TaskDescriptor<Void> FAILING_ONETIME_TASK_BACKOFF =
+      TaskDescriptor.of("failing-one-time-with-backoff-task");
 
   @Bean
   public Task<?> runOneTimeFailing() {

--- a/example-app/src/main/java/com/github/bekk/exampleapp/tasks/LongRunningTask.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/tasks/LongRunningTask.java
@@ -16,7 +16,7 @@ package com.github.bekk.exampleapp.tasks;
 import static utils.Utils.sleep;
 
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithoutDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import org.springframework.context.annotation.Bean;
@@ -25,11 +25,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class LongRunningTask {
 
-  public static final TaskWithoutDataDescriptor LONG_RUNNING_ONETIME_TASK =
-      new TaskWithoutDataDescriptor("long-running-task");
+  public static final TaskDescriptor<Void> LONG_RUNNING_ONETIME_TASK =
+      TaskDescriptor.of("long-running-task");
 
-  public static final TaskWithoutDataDescriptor LONG_RUNNING_RECURRING_TASK =
-      new TaskWithoutDataDescriptor("long-running-recurring-task");
+  public static final TaskDescriptor<Void> LONG_RUNNING_RECURRING_TASK =
+      TaskDescriptor.of("long-running-recurring-task");
 
   @Bean
   public Task<?> runLongRunningTask() {

--- a/example-app/src/main/java/com/github/bekk/exampleapp/tasks/OneTimeTaskExample.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/tasks/OneTimeTaskExample.java
@@ -15,7 +15,7 @@ package com.github.bekk.exampleapp.tasks;
 
 import com.github.bekk.exampleapp.model.TaskData;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,8 +23,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OneTimeTaskExample {
 
-  public static final TaskWithDataDescriptor<TaskData> ONE_TIME_TASK =
-      new TaskWithDataDescriptor<>("onetime-task", TaskData.class);
+  public static final TaskDescriptor<TaskData> ONE_TIME_TASK =
+      TaskDescriptor.of("onetime-task", TaskData.class);
 
   @Bean
   public Task<TaskData> exampleOneTimeTask() {

--- a/example-app/src/main/java/com/github/bekk/exampleapp/tasks/RecurringTaskExample.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/tasks/RecurringTaskExample.java
@@ -15,7 +15,7 @@ package com.github.bekk.exampleapp.tasks;
 
 import static utils.Utils.sleep;
 
-import com.github.kagkarlsson.scheduler.task.TaskWithoutDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
@@ -26,8 +26,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RecurringTaskExample {
 
-  public static final TaskWithoutDataDescriptor RECURRING_TASK =
-      new TaskWithoutDataDescriptor("recurring-task");
+  public static final TaskDescriptor<Void> RECURRING_TASK =
+      TaskDescriptor.of("recurring-task");
 
   @Bean
   public RecurringTask<Void> getExample() {

--- a/example-app/src/main/java/com/github/bekk/exampleapp/tasks/SpawnerTask.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/tasks/SpawnerTask.java
@@ -18,8 +18,7 @@ import static utils.Utils.sleep;
 import com.github.bekk.exampleapp.model.TaskData;
 import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
-import com.github.kagkarlsson.scheduler.task.TaskWithoutDataDescriptor;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import java.time.Instant;
@@ -31,11 +30,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SpawnerTask {
 
-  public static final TaskWithoutDataDescriptor RECURRING_SPAWNER_TASK =
-      new TaskWithoutDataDescriptor("recurring-spawner-task");
+  public static final TaskDescriptor<Void> RECURRING_SPAWNER_TASK =
+      TaskDescriptor.of("recurring-spawner-task");
 
-  public static final TaskWithDataDescriptor<TaskData> ONE_TIME_SPAWNER_TASK =
-      new TaskWithDataDescriptor<>("onetime-spawned-task", TaskData.class);
+  public static final TaskDescriptor<TaskData> ONE_TIME_SPAWNER_TASK =
+      TaskDescriptor.of("onetime-spawned-task", TaskData.class);
 
   @Bean
   public Task<?> runSpawner() {
@@ -46,10 +45,10 @@ public class SpawnerTask {
               final long randomUUID = UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
 
               for (int i = 0; i < 100; i++) {
-                client.schedule(
-                    ONE_TIME_SPAWNER_TASK.instance(
-                        "spawned " + randomUUID + " loopnr: " + i,
-                        new TaskData(123, "{data: MASSIVEDATA}", Instant.now())),
+                client.scheduleIfNotExists(
+                    ONE_TIME_SPAWNER_TASK.instance("spawned " + randomUUID + " loopnr: " + i)
+                        .data(new TaskData(123, "{data: MASSIVEDATA}", Instant.now()))
+                        .build(),
                     Instant.now().plusSeconds(60));
               }
             });

--- a/example-app/src/test/java/com/github/bekk/exampleapp/DynamicRecurringSchedulingTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/DynamicRecurringSchedulingTest.java
@@ -41,8 +41,8 @@ public class DynamicRecurringSchedulingTest {
     CronSchedule cron = Schedules.cron("0 0/1 * * * *"); // every minute
     TaskScheduleAndNoData data = new TaskScheduleAndNoData(cron);
 
-    schedulerClient.schedule(
-        DYNAMIC_RECURRING_TASK.instance("single_instance", data),
+    schedulerClient.scheduleIfNotExists(
+        DYNAMIC_RECURRING_TASK.instance("single_instance").data(data).build(),
         cron.getInitialExecutionTime(Instant.now()));
 
     // When
@@ -54,7 +54,7 @@ public class DynamicRecurringSchedulingTest {
             GetTasksResponse.class);
 
     // Then
-    Assertions.assertEquals(result.getStatusCode(), HttpStatus.OK);
+    Assertions.assertEquals(HttpStatus.OK, result.getStatusCode());
     result.getBody().getItems().forEach(t -> System.out.println(t.getTaskName()));
     assertThat(result.getBody().getItems())
         .anyMatch(

--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,9 @@
     </distributionManagement>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-        <spring-boot.version>2.7.18</spring-boot.version>
-        <db-scheduler.version>14.0.0</db-scheduler.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <spring-boot.version>3.4.1</spring-boot.version>
+        <db-scheduler.version>15.1.1</db-scheduler.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -80,7 +80,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.2</version>
+                <version>5.11.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -118,12 +118,12 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.5.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -136,7 +136,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.11.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -146,7 +146,7 @@
                 <plugin>
                     <groupId>org.jreleaser</groupId>
                     <artifactId>jreleaser-maven-plugin</artifactId>
-                    <version>1.12.0</version>
+                    <version>1.16.0</version>
                     <configuration>
                         <jreleaser>
                             <release>
@@ -193,7 +193,7 @@
             <plugin>
                 <groupId>com.github.ekryd.sortpom</groupId>
                 <artifactId>sortpom-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>4.0.0</version>
                 <configuration>
                     <nrOfIndentSpace>4</nrOfIndentSpace>
                     <createBackupFile>false</createBackupFile>
@@ -218,7 +218,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.2.7</version>
                 <configuration>
                     <gpgArguments>
                         <arg>--pinentry-mode</arg>
@@ -264,7 +264,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>4.5</version>
+                <version>4.6</version>
                 <configuration>
                     <mapping>
                         <ts>SLASHSTAR_STYLE</ts>
@@ -313,7 +313,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>


### PR DESCRIPTION
* upgrade to the latest Spring Boot 3.4.1
* use Java 17 (requirement for SB 3)
* upgrade db-scheduler to the latest version & fix deprecated usage
* upgrade & update plugins to their latest version
* introduce spring-boot-configuration-processor to generate configuration metadata

fixes #127