### PR TITLE
Read-only mode and Spring Security example

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spring-boot: [ '3.3.7', '3.4.1' ]
+        spring-boot: [ '3.3.8', '3.4.2' ]
 
     steps:
       - name: Checkout repo

--- a/db-scheduler-ui-frontend/src/components/input/DotButton.tsx
+++ b/db-scheduler-ui-frontend/src/components/input/DotButton.tsx
@@ -32,6 +32,7 @@ import { CalendarIcon, DeleteIcon, InfoOutlineIcon } from '@chakra-ui/icons';
 import { IoEllipsisVerticalIcon } from '../../assets/icons';
 import { useNavigate } from 'react-router-dom';
 import { ScheduleRunAlert } from './ScheduleRunAlert';
+import { getReadonly } from 'src/utils/config';
 
 interface TaskProps {
   taskName: string;
@@ -65,6 +66,7 @@ export const DotButton: React.FC<TaskProps> = ({
 
         <MenuList padding={0}>
           <MenuItem
+            display={getReadonly() ? 'none' : 'unset'}
             rounded={6}
             minBlockSize={10}
             onClick={(event) => {
@@ -87,6 +89,7 @@ export const DotButton: React.FC<TaskProps> = ({
             See history for task
           </MenuItem>
           <MenuItem
+            display={getReadonly() ? 'none' : 'unset'}
             rounded={6}
             minBlockSize={10}
             onClick={(event) => {

--- a/db-scheduler-ui-frontend/src/components/scheduled/TaskAccordionButton.tsx
+++ b/db-scheduler-ui-frontend/src/components/scheduled/TaskAccordionButton.tsx
@@ -30,6 +30,7 @@ import { NumberCircleGroup } from 'src/components/common/NumberCircleGroup';
 import { AttachmentIcon } from '@chakra-ui/icons';
 import { determineStatus, isStatus } from 'src/utils/determineStatus';
 import colors from 'src/styles/colors';
+import { getReadonly } from 'src/utils/config';
 
 interface TaskAccordionButtonProps extends Task {
   refetch: () => void;
@@ -128,7 +129,11 @@ export const TaskAccordionButton: React.FC<TaskAccordionButtonProps> = (
               }
               w={150}
             >
-              <TaskRunButton {...props} refetch={refetch} />
+              <TaskRunButton
+                {...props}
+                refetch={refetch}
+                style={{ visibility: getReadonly() ? 'hidden' : 'visible' }}
+              />
               <DotButton
                 taskName={taskName}
                 taskInstance={taskInstance[0]}

--- a/db-scheduler-ui-frontend/src/services/deleteTask.ts
+++ b/db-scheduler-ui-frontend/src/services/deleteTask.ts
@@ -23,7 +23,9 @@ const deleteTask = async (id: string, name: string) => {
     },
   );
 
-  if (!response.ok) {
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
     throw new Error(`Error executing task. Status: ${response.statusText}`);
   }
 };

--- a/db-scheduler-ui-frontend/src/services/getLogs.ts
+++ b/db-scheduler-ui-frontend/src/services/getLogs.ts
@@ -62,7 +62,9 @@ export const getLogs = async (
     },
   });
 
-  if (!response.ok) {
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
     throw new Error(`Error fetching logs. Status: ${response.statusText}`);
   }
 

--- a/db-scheduler-ui-frontend/src/services/getTask.ts
+++ b/db-scheduler-ui-frontend/src/services/getTask.ts
@@ -60,7 +60,9 @@ export const getTask = async (
     },
   });
 
-  if (!response.ok) {
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
     throw new Error(`Error fetching tasks. Status: ${response.statusText}`);
   }
 

--- a/db-scheduler-ui-frontend/src/services/getTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/getTasks.ts
@@ -58,7 +58,9 @@ export const getTasks = async (
     },
   });
 
-  if (!response.ok) {
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
     throw new Error(`Error fetching tasks. Status: ${response.statusText}`);
   }
 

--- a/db-scheduler-ui-frontend/src/services/pollLogs.ts
+++ b/db-scheduler-ui-frontend/src/services/pollLogs.ts
@@ -60,7 +60,9 @@ export const pollLogs = async (
     },
   });
 
-  if (!response.ok) {
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
     throw new Error(`Error polling tasks. Status: ${response.statusText}`);
   }
 

--- a/db-scheduler-ui-frontend/src/services/pollTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/pollTasks.ts
@@ -60,8 +60,9 @@ export const pollTasks = async (
       'Content-Type': 'application/json',
     },
   });
-
-  if (!response.ok) {
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
     throw new Error(`Error polling tasks. Status: ${response.statusText}`);
   }
 

--- a/db-scheduler-ui-frontend/src/services/runTask.ts
+++ b/db-scheduler-ui-frontend/src/services/runTask.ts
@@ -34,7 +34,9 @@ const runTask = async (id: string, name: string, scheduleTime?:Date) => {
     },
   );
 
-  if (!response.ok) {
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
     throw new Error(`Error executing task. Status: ${response.statusText}`);
   }
 };

--- a/db-scheduler-ui-frontend/src/services/runTaskGroup.ts
+++ b/db-scheduler-ui-frontend/src/services/runTaskGroup.ts
@@ -23,7 +23,9 @@ const runTaskGroup = async (name: string, onlyFailed: boolean) => {
     },
   );
 
-  if (!response.ok) {
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
     throw new Error(`Error executing task. Status: ${response.statusText}`);
   }
 };

--- a/db-scheduler-ui-frontend/src/utils/config.ts
+++ b/db-scheduler-ui-frontend/src/utils/config.ts
@@ -19,4 +19,7 @@ const config = await fetch('/db-scheduler-api/config').then((res) =>
 const showHistory =
   'showHistory' in config ? Boolean(config.showHistory) : false;
 
+const readOnly = 'readOnly' in config ? Boolean(config.readOnly) : false;
+
 export const getShowHistory = (): boolean => showHistory;
+export const getReadonly = (): boolean => readOnly;

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -20,6 +20,7 @@ import javax.sql.DataSource;
 import no.bekk.dbscheduler.ui.controller.ConfigController;
 import no.bekk.dbscheduler.ui.controller.LogController;
 import no.bekk.dbscheduler.ui.controller.SpaFallbackMvc;
+import no.bekk.dbscheduler.ui.controller.TaskAdminController;
 import no.bekk.dbscheduler.ui.controller.TaskController;
 import no.bekk.dbscheduler.ui.service.LogLogic;
 import no.bekk.dbscheduler.ui.service.TaskLogic;
@@ -90,6 +91,17 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "read-only",
+      havingValue = "false",
+      matchIfMissing = true)
+  TaskAdminController taskAdminController(TaskLogic taskLogic) {
+    return new TaskAdminController(taskLogic);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
   TaskController taskController(TaskLogic taskLogic) {
     return new TaskController(taskLogic);
   }
@@ -125,6 +137,6 @@ public class UiApiAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   ConfigController configController(DbSchedulerUiProperties properties) {
-    return new ConfigController(properties.isHistory());
+    return new ConfigController(properties.isHistory(), properties::isReadOnly);
   }
 }

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DbSchedulerUiProperties {
 
   private boolean enabled = true;
+  private boolean readOnly = false;
   private boolean taskData = true;
   private boolean history = false;
   private int logLimit = 0;

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/ConfigController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/ConfigController.java
@@ -13,6 +13,7 @@
  */
 package no.bekk.dbscheduler.ui.controller;
 
+import java.util.function.Supplier;
 import no.bekk.dbscheduler.ui.model.ConfigResponse;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,13 +26,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class ConfigController {
 
   private final boolean showHistory;
+  private final Supplier<Boolean> readOnly;
 
-  public ConfigController(boolean showHistory) {
+  public ConfigController(boolean showHistory, Supplier<Boolean> readOnly) {
     this.showHistory = showHistory;
+    this.readOnly = readOnly;
   }
 
   @GetMapping
   public ConfigResponse getConfig() {
-    return new ConfigResponse(showHistory);
+    return new ConfigResponse(showHistory, readOnly.get());
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/TaskAdminController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/TaskAdminController.java
@@ -13,40 +13,46 @@
  */
 package no.bekk.dbscheduler.ui.controller;
 
-import no.bekk.dbscheduler.ui.model.GetTasksResponse;
-import no.bekk.dbscheduler.ui.model.PollResponse;
-import no.bekk.dbscheduler.ui.model.TaskDetailsRequestParams;
-import no.bekk.dbscheduler.ui.model.TaskRequestParams;
+import java.time.Instant;
 import no.bekk.dbscheduler.ui.service.TaskLogic;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @CrossOrigin
 @RequestMapping("/db-scheduler-api/tasks")
-public class TaskController {
+@ConditionalOnProperty(
+    prefix = "db-scheduler-ui",
+    name = "read-only",
+    havingValue = "false",
+    matchIfMissing = true)
+public class TaskAdminController {
+
   private final TaskLogic taskLogic;
 
   @Autowired
-  public TaskController(TaskLogic taskLogic) {
+  public TaskAdminController(TaskLogic taskLogic) {
     this.taskLogic = taskLogic;
   }
 
-  @GetMapping("/all")
-  public GetTasksResponse getTasks(TaskRequestParams params) {
-    return taskLogic.getAllTasks(params);
+  @PostMapping("/rerun")
+  public void runNow(
+      @RequestParam String id, @RequestParam String name, @RequestParam Instant scheduleTime) {
+    taskLogic.runTaskNow(id, name, scheduleTime);
   }
 
-  @GetMapping("/details")
-  public GetTasksResponse getTaskDetails(TaskDetailsRequestParams params) {
-    return taskLogic.getTask(params);
+  @PostMapping("/rerunGroup")
+  public void runAllNow(@RequestParam String name, @RequestParam boolean onlyFailed) {
+    taskLogic.runTaskGroupNow(name, onlyFailed);
   }
 
-  @GetMapping("/poll")
-  public PollResponse pollForUpdates(TaskDetailsRequestParams params) {
-    return taskLogic.pollTasks(params);
+  @PostMapping("/delete")
+  public void deleteTaskNow(@RequestParam String id, @RequestParam String name) {
+    taskLogic.deleteTask(id, name);
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/ConfigResponse.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/ConfigResponse.java
@@ -22,4 +22,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ConfigResponse {
   private boolean showHistory;
+  private boolean readOnly;
 }

--- a/example-app-webflux/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
+++ b/example-app-webflux/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
@@ -3,7 +3,7 @@ package com.github.bekk.exampleapp;
 import static com.github.bekk.exampleapp.tasks.OneTimeTaskExample.ONE_TIME_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import no.bekk.dbscheduler.ui.controller.TaskController;
+import no.bekk.dbscheduler.ui.controller.TaskAdminController;
 import no.bekk.dbscheduler.ui.model.GetTasksResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +23,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class SmokeTest {
 
-  @Autowired TaskController controller;
+  @Autowired TaskAdminController controller;
   @LocalServerPort private Integer serverPort;
   private String baseUrl;
   @Autowired private TestRestTemplate restTemplate;

--- a/example-app/pom.xml
+++ b/example-app/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/example-app/src/main/java/com/github/bekk/exampleapp/service/TaskService.java
+++ b/example-app/src/main/java/com/github/bekk/exampleapp/service/TaskService.java
@@ -48,5 +48,19 @@ public class TaskService {
     scheduler.schedule(
         LONG_RUNNING_ONETIME_TASK.instance("5").build(), Instant.now().plusSeconds(2));
     scheduler.schedule(FAILING_ONETIME_TASK.instance("6").build(), Instant.now().plusSeconds(2));
+
+    scheduler.schedule(
+        ONE_TIME_TASK
+            .instance("delete-1")
+            .data(new TaskData(-1, "task 1 to delete", Instant.now()))
+            .build(),
+        Instant.now());
+
+    scheduler.schedule(
+        ONE_TIME_TASK
+            .instance("delete-2")
+            .data(new TaskData(-2, "task 2 to delete", Instant.now()))
+            .build(),
+        Instant.now());
   }
 }

--- a/example-app/src/test/java/com/github/bekk/exampleapp/DynamicRecurringSchedulingTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/DynamicRecurringSchedulingTest.java
@@ -8,27 +8,27 @@ import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.schedule.CronSchedule;
 import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
 import java.time.Instant;
-import no.bekk.dbscheduler.ui.controller.TaskController;
 import no.bekk.dbscheduler.ui.model.GetTasksResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
     classes = {ExampleApp.class},
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class DynamicRecurringSchedulingTest {
+@EnableAutoConfiguration(
+    exclude = {SecurityAutoConfiguration.class, ManagementWebSecurityAutoConfiguration.class})
+class DynamicRecurringSchedulingTest {
 
-  @Autowired TaskController controller;
   @LocalServerPort private Integer serverPort;
   private String baseUrl;
   @Autowired private TestRestTemplate restTemplate;
@@ -36,7 +36,7 @@ public class DynamicRecurringSchedulingTest {
   @Autowired private SchedulerClient schedulerClient;
 
   @Test
-  public void testGetTasksReturnsDynamicRecurringTask() {
+  void testGetTasksReturnsDynamicRecurringTask() {
     // Given
     CronSchedule cron = Schedules.cron("0 0/1 * * * *"); // every minute
     TaskScheduleAndNoData data = new TaskScheduleAndNoData(cron);

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeReadOnlyTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeReadOnlyTest.java
@@ -1,7 +1,6 @@
 package com.github.bekk.exampleapp;
 
 import static com.github.bekk.exampleapp.tasks.FailingTask.FAILING_ONETIME_TASK;
-import static com.github.bekk.exampleapp.tasks.OneTimeTaskExample.ONE_TIME_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import no.bekk.dbscheduler.ui.model.GetTasksResponse;
@@ -12,6 +11,7 @@ import org.springframework.boot.actuate.autoconfigure.security.servlet.Managemen
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContext;
@@ -19,13 +19,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(
-    classes = {ExampleApp.class},
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    properties = "db-scheduler-ui.read-only=true",
+    classes = ExampleApp.class,
+    webEnvironment = WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(
     exclude = {SecurityAutoConfiguration.class, ManagementWebSecurityAutoConfiguration.class})
-class SmokeTest {
+class SmokeReadOnlyTest {
 
-  @LocalServerPort private Integer serverPort;
+  @LocalServerPort private int serverPort;
 
   private String baseUrl;
 
@@ -33,42 +34,28 @@ class SmokeTest {
 
   @Autowired private TestRestTemplate restTemplate;
 
+  @BeforeEach
+  void setUp() {
+    baseUrl = "http://localhost:" + serverPort;
+  }
+
   @Test
   void testContextLoads() {
-    assertThat(context.containsBean("taskAdminController")).isTrue();
+    assertThat(context.containsBean("taskAdminController")).isFalse();
     assertThat(context.containsBean("taskController")).isTrue();
   }
 
   @Test
-  void testGetTasksReturnsStatusOK() {
+  void readingTasksWorks() {
     ResponseEntity<GetTasksResponse> result =
-        this.restTemplate.getForEntity(
-            baseUrl
-                + "/db-scheduler-api/tasks/all?filter=ALL&pageNumber=0&size=10&sorting=DEFAULT&asc=true&searchTerm="
-                + ONE_TIME_TASK.getTaskName(),
-            GetTasksResponse.class);
+        restTemplate.getForEntity(baseUrl + "/db-scheduler-api/tasks/all", GetTasksResponse.class);
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(result.getBody()).isNotNull();
     assertThat(result.getBody().getItems()).isNotEmpty();
   }
 
   @Test
-  void testGetTasksReturnsExampleOneTimeTask() {
-    ResponseEntity<GetTasksResponse> result =
-        this.restTemplate.getForEntity(
-            baseUrl
-                + "/db-scheduler-api/tasks/all?filter=ALL&pageNumber=0&size=10&sorting=DEFAULT&asc=true&searchTerm="
-                + ONE_TIME_TASK.getTaskName(),
-            GetTasksResponse.class);
-    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(result.getBody()).isNotNull();
-    result.getBody().getItems().forEach(t -> System.out.println(t.getTaskName()));
-    assertThat(result.getBody().getItems())
-        .anyMatch(taskModel -> taskModel.getTaskName().equals(ONE_TIME_TASK.getTaskName()));
-  }
-
-  @Test
-  void deletingTaskReturnsStatusOK() {
+  void deletingTasksIsNotAvailableInReadOnlyMode() {
     ResponseEntity<Void> result =
         restTemplate.postForEntity(
             baseUrl
@@ -77,11 +64,6 @@ class SmokeTest {
             null,
             Void.class);
 
-    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-  }
-
-  @BeforeEach
-  void setUp() {
-    baseUrl = "http://localhost:" + serverPort;
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
   }
 }

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeSpringSecurityTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeSpringSecurityTest.java
@@ -1,0 +1,223 @@
+package com.github.bekk.exampleapp;
+
+import static com.github.bekk.exampleapp.tasks.FailingTask.FAILING_ONETIME_TASK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import com.github.bekk.exampleapp.SmokeSpringSecurityTest.TestConfig;
+import java.util.function.Supplier;
+import no.bekk.dbscheduler.ui.controller.ConfigController;
+import no.bekk.dbscheduler.ui.model.ConfigResponse;
+import no.bekk.dbscheduler.ui.model.GetTasksResponse;
+import no.bekk.dbscheduler.uistarter.config.DbSchedulerUiProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = ExampleApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import(TestConfig.class)
+class SmokeSpringSecurityTest {
+
+  @LocalServerPort private int serverPort;
+
+  @Autowired private ApplicationContext context;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  private String baseUrl;
+  private TestRestTemplate userRestTemplate;
+  private TestRestTemplate adminRestTemplate;
+
+  @BeforeEach
+  void setUp() {
+    baseUrl = "http://localhost:" + serverPort;
+    userRestTemplate = restTemplate.withBasicAuth("user", "user");
+    adminRestTemplate = restTemplate.withBasicAuth("admin", "admin");
+  }
+
+  @Configuration
+  @EnableWebSecurity
+  static class TestConfig {
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+      return http.csrf(CsrfConfigurer::disable)
+          .authorizeHttpRequests(
+              authz ->
+                  authz
+                      // protect the UI
+                      .requestMatchers("/db-scheduler/**")
+                      .hasAnyRole("ADMIN", "USER")
+                      // allow read access to the API for both users and admins
+                      .requestMatchers(HttpMethod.GET, "/db-scheduler-api/**")
+                      .hasAnyRole("ADMIN", "USER")
+                      // only admins can delete tasks, alter scheduling, ...
+                      .requestMatchers(HttpMethod.POST, "/db-scheduler-api/**")
+                      .hasAnyRole("ADMIN")
+                      // other application specific security
+                      .anyRequest()
+                      .permitAll())
+          .httpBasic(withDefaults())
+          .build();
+    }
+
+    @Bean
+    UserDetailsManager userDetailsService() {
+      UserDetails user = User.withUsername("user").password("{noop}user").roles("USER").build();
+      UserDetails admin = User.withUsername("admin").password("{noop}admin").roles("ADMIN").build();
+      return new InMemoryUserDetailsManager(user, admin);
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+      AuthenticationManagerBuilder authenticationManagerBuilder =
+          http.getSharedObject(AuthenticationManagerBuilder.class);
+      authenticationManagerBuilder.userDetailsService(userDetailsService());
+      return authenticationManagerBuilder.build();
+    }
+
+    @Bean
+    ConfigController configController(DbSchedulerUiProperties properties) {
+      return new ConfigController(properties.isHistory(), readOnly(properties));
+    }
+
+    private Supplier<Boolean> readOnly(DbSchedulerUiProperties properties) {
+      return () -> properties.isReadOnly() || !isAdmin();
+    }
+
+    private boolean isAdmin() {
+      Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+      if (auth == null) {
+        return false;
+      }
+      return auth.getAuthorities().stream().anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority()));
+    }
+  }
+
+  @Test
+  void testContextLoads() {
+    assertThat(context.containsBean("taskAdminController")).isTrue();
+    assertThat(context.containsBean("taskController")).isTrue();
+  }
+
+  @Test
+  void accessingUiWithoutCredentialsIsUnauthorized() {
+    ResponseEntity<String> result =
+        restTemplate.getForEntity(baseUrl + "/db-scheduler", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  void accessingUiWorksForUser() {
+    ResponseEntity<String> result =
+        userRestTemplate.getForEntity(baseUrl + "/db-scheduler", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).contains("<title>DB Scheduler UI</title>");
+  }
+
+  @Test
+  void accessingUiWorksForAdmin() {
+    ResponseEntity<String> result =
+        adminRestTemplate.getForEntity(baseUrl + "/db-scheduler", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).contains("<title>DB Scheduler UI</title>");
+  }
+
+  @Test
+  void readingTasksWithoutCredentialsIsUnauthorized() {
+    ResponseEntity<GetTasksResponse> result =
+        restTemplate.getForEntity(baseUrl + "/db-scheduler-api/tasks/all", GetTasksResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  void readingTasksWorksForUser() {
+    ResponseEntity<GetTasksResponse> result =
+        userRestTemplate.getForEntity(
+            baseUrl + "/db-scheduler-api/tasks/all", GetTasksResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void readingTasksWorksForAdmin() {
+    ResponseEntity<GetTasksResponse> result =
+        adminRestTemplate.getForEntity(
+            baseUrl + "/db-scheduler-api/tasks/all", GetTasksResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void deletingTasksIsForbiddenForUser() {
+    ResponseEntity<Void> result =
+        userRestTemplate.postForEntity(
+            baseUrl
+                + "/db-scheduler-api/tasks/delete?id=%d&name=%s"
+                    .formatted(6, FAILING_ONETIME_TASK.getTaskName()),
+            null,
+            Void.class);
+
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  void deletingTasksWorksForAdmin() {
+    ResponseEntity<Void> result =
+        adminRestTemplate.postForEntity(
+            baseUrl
+                + "/db-scheduler-api/tasks/delete?id=%d&name=%s"
+                    .formatted(6, FAILING_ONETIME_TASK.getTaskName()),
+            null,
+            Void.class);
+
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void configIndicatesReadOnlyForUser() {
+    ResponseEntity<ConfigResponse> result =
+        userRestTemplate.getForEntity(baseUrl + "/db-scheduler-api/config", ConfigResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody())
+        .isNotNull()
+        .extracting(ConfigResponse::isReadOnly, BOOLEAN)
+        .isTrue();
+  }
+
+  @Test
+  void configIndicatesNotReadOnlyForAdmin() {
+    ResponseEntity<ConfigResponse> result =
+        adminRestTemplate.getForEntity(baseUrl + "/db-scheduler-api/config", ConfigResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody())
+        .isNotNull()
+        .extracting(ConfigResponse::isReadOnly, BOOLEAN)
+        .isFalse();
+  }
+}

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeSpringSecurityTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeSpringSecurityTest.java
@@ -1,6 +1,6 @@
 package com.github.bekk.exampleapp;
 
-import static com.github.bekk.exampleapp.tasks.FailingTask.FAILING_ONETIME_TASK;
+import static com.github.bekk.exampleapp.tasks.OneTimeTaskExample.ONE_TIME_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
 import static org.springframework.security.config.Customizer.withDefaults;
@@ -178,8 +178,8 @@ class SmokeSpringSecurityTest {
     ResponseEntity<Void> result =
         userRestTemplate.postForEntity(
             baseUrl
-                + "/db-scheduler-api/tasks/delete?id=%d&name=%s"
-                    .formatted(6, FAILING_ONETIME_TASK.getTaskName()),
+                + "/db-scheduler-api/tasks/delete?id=%s&name=%s"
+                    .formatted("delete-2", ONE_TIME_TASK.getTaskName()),
             null,
             Void.class);
 
@@ -191,8 +191,8 @@ class SmokeSpringSecurityTest {
     ResponseEntity<Void> result =
         adminRestTemplate.postForEntity(
             baseUrl
-                + "/db-scheduler-api/tasks/delete?id=%d&name=%s"
-                    .formatted(6, FAILING_ONETIME_TASK.getTaskName()),
+                + "/db-scheduler-api/tasks/delete?id=%s&name=%s"
+                    .formatted("delete-2", ONE_TIME_TASK.getTaskName()),
             null,
             Void.class);
 

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
@@ -1,6 +1,5 @@
 package com.github.bekk.exampleapp;
 
-import static com.github.bekk.exampleapp.tasks.FailingTask.FAILING_ONETIME_TASK;
 import static com.github.bekk.exampleapp.tasks.OneTimeTaskExample.ONE_TIME_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,8 +71,8 @@ class SmokeTest {
     ResponseEntity<Void> result =
         restTemplate.postForEntity(
             baseUrl
-                + "/db-scheduler-api/tasks/delete?id=%d&name=%s"
-                    .formatted(6, FAILING_ONETIME_TASK.getTaskName()),
+                + "/db-scheduler-api/tasks/delete?id=%s&name=%s"
+                    .formatted("delete-1", ONE_TIME_TASK.getTaskName()),
             null,
             Void.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
-        <spring-boot.version>3.4.1</spring-boot.version>
-        <db-scheduler.version>15.1.1</db-scheduler.version>
+        <spring-boot.version>3.4.2</spring-boot.version>
+        <db-scheduler.version>15.1.2</db-scheduler.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
* introduce a read-only mode in which you can only consult tasks but not alter them
  * controller separation
  * config for frontend
  * ui changes to hide buttons
* provide Spring Security example
  * option to alter frontend config at runtime
  * test with sample config and tests
  * navigate to root when fetching results in unauthorized (e.g. due to session timeout)
* bump SB and db-scheduler versions

fixes #126