### PR TITLE
131: update `Getting started` docs to reference latest version (4.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dashboard for monitoring and basic administration of tasks.
 <dependency>
     <groupId>no.bekk.db-scheduler-ui</groupId>
     <artifactId>db-scheduler-ui-starter</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Closes #131 by updating the `Getting Started` docs to reference latest version [4.1.0](https://github.com/bekk/db-scheduler-ui/releases/tag/v4.1.0).