### PR TITLE
Allow to override context path at runtime

### DIFF
--- a/db-scheduler-ui-frontend/main.tsx
+++ b/db-scheduler-ui-frontend/main.tsx
@@ -15,7 +15,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './src/App';
 
-const basename = import.meta.env.BASE_URL;
+const basename = (window.CONTEXT_PATH || '') + import.meta.env.BASE_URL;
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <BrowserRouter basename={basename}>

--- a/db-scheduler-ui-frontend/src/services/deleteTask.ts
+++ b/db-scheduler-ui-frontend/src/services/deleteTask.ts
@@ -13,7 +13,7 @@
  */
 const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + '/db-scheduler-api';
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
 
 const deleteTask = async (id: string, name: string) => {
   const response = await fetch(

--- a/db-scheduler-ui-frontend/src/services/getLogs.ts
+++ b/db-scheduler-ui-frontend/src/services/getLogs.ts
@@ -17,7 +17,7 @@ import { LogResponse } from 'src/models/TasksResponse';
 
 const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + '/db-scheduler-api';
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
 
 export const ALL_LOG_QUERY_KEY = `logs/all`;
 

--- a/db-scheduler-ui-frontend/src/services/getTask.ts
+++ b/db-scheduler-ui-frontend/src/services/getTask.ts
@@ -16,7 +16,7 @@ import { TaskDetailsRequestParams } from 'src/models/TaskRequestParams';
 
 const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + '/db-scheduler-api';
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
 
 export const TASK_DETAILS_QUERY_KEY = `tasks/details`;
 

--- a/db-scheduler-ui-frontend/src/services/getTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/getTasks.ts
@@ -16,7 +16,7 @@ import { TaskRequestParams } from 'src/models/TaskRequestParams';
 
 const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + '/db-scheduler-api';
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
 
 export const TASK_QUERY_KEY = `tasks`;
 

--- a/db-scheduler-ui-frontend/src/services/pollLogs.ts
+++ b/db-scheduler-ui-frontend/src/services/pollLogs.ts
@@ -16,7 +16,7 @@ import { TaskDetailsRequestParams } from 'src/models/TaskRequestParams';
 
 const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + '/db-scheduler-api';
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
 
 export const POLL_LOGS_QUERY_KEY = `logs/poll`;
 

--- a/db-scheduler-ui-frontend/src/services/pollTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/pollTasks.ts
@@ -16,7 +16,7 @@ import { TaskDetailsRequestParams } from 'src/models/TaskRequestParams';
 
 const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + '/db-scheduler-api';
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
 
 export const POLL_TASKS_QUERY_KEY = `tasks/poll`;
 

--- a/db-scheduler-ui-frontend/src/services/runTask.ts
+++ b/db-scheduler-ui-frontend/src/services/runTask.ts
@@ -13,7 +13,7 @@
  */
 const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + '/db-scheduler-api';
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
 
 const runTask = async (id: string, name: string, scheduleTime?:Date) => {
 

--- a/db-scheduler-ui-frontend/src/services/runTaskGroup.ts
+++ b/db-scheduler-ui-frontend/src/services/runTaskGroup.ts
@@ -13,7 +13,7 @@
  */
 const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + '/db-scheduler-api';
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
 
 const runTaskGroup = async (name: string, onlyFailed: boolean) => {
   const response = await fetch(

--- a/db-scheduler-ui-frontend/src/utils/global.d.ts
+++ b/db-scheduler-ui-frontend/src/utils/global.d.ts
@@ -11,19 +11,11 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export {};
 
-const API_BASE_URL: string =
-    (import.meta.env.VITE_API_BASE_URL as string) ??
-    window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
-
-const config = await fetch(`${API_BASE_URL}/config`).then((res) =>
-  res.json(),
-);
-
-const showHistory =
-  'showHistory' in config ? Boolean(config.showHistory) : false;
-
-const readOnly = 'readOnly' in config ? Boolean(config.readOnly) : false;
-
-export const getShowHistory = (): boolean => showHistory;
-export const getReadonly = (): boolean => readOnly;
+declare global {
+    interface Window {
+        /** Path to prepended to API calls and the router basename (optional). */
+        CONTEXT_PATH: string;
+    }
+}

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -16,8 +16,10 @@ package no.bekk.dbscheduler.uistarter.autoconfigure;
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
+import java.io.IOException;
 import javax.sql.DataSource;
 import no.bekk.dbscheduler.ui.controller.ConfigController;
+import no.bekk.dbscheduler.ui.controller.IndexHtmlController;
 import no.bekk.dbscheduler.ui.controller.LogController;
 import no.bekk.dbscheduler.ui.controller.SpaFallbackMvc;
 import no.bekk.dbscheduler.ui.controller.TaskAdminController;
@@ -138,5 +140,13 @@ public class UiApiAutoConfiguration {
   @ConditionalOnMissingBean
   ConfigController configController(DbSchedulerUiProperties properties) {
     return new ConfigController(properties.isHistory(), properties::isReadOnly);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnProperty(prefix = "server.servlet", name = "context-path")
+  IndexHtmlController indexHtmlController(
+      @Value("${server.servlet.context-path}") String contextPath) throws IOException {
+    return new IndexHtmlController(contextPath);
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/IndexHtmlController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/IndexHtmlController.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.bekk.dbscheduler.ui.controller;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class IndexHtmlController {
+
+  private final String patchedIndexHtml;
+
+  public IndexHtmlController(String contextPath) throws IOException {
+    this.patchedIndexHtml = contextPathAwareIndexHtml(contextPath);
+  }
+
+  @GetMapping(
+      path = {"/db-scheduler/index.html", "/db-scheduler"},
+      produces = MediaType.TEXT_HTML_VALUE)
+  String indexHtml() {
+    return patchedIndexHtml;
+  }
+
+  private static String contextPathAwareIndexHtml(String contextPath) throws IOException {
+    String indexHtml =
+        new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE)
+            .getContentAsString(StandardCharsets.UTF_8);
+
+    return indexHtml
+        .replaceAll("/db-scheduler", contextPath + "/db-scheduler")
+        .replaceAll(
+            "<head>",
+            """
+                <head>
+                    <script>
+                      window.CONTEXT_PATH = '%s';
+                    </script>"""
+                .formatted(contextPath));
+  }
+}


### PR DESCRIPTION
Tried to implement something like #122. The solution is based on Spring's context path variable.

Since this involves replacing & injecting the path into the statically generated index.html, I added a controller, which loads the index.html from the classpath and modifies it. This is a little workaround, but I wasn't able to come up with a better solution. On the other hand, this makes it possible to work with a Spring context path other than '/'.

I would appreciate some feedback on this.