### PR TITLE
fix: frontend build on fresh checkout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,8 +317,9 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>frontend/node_modules</directory>
                             <directory>db-scheduler-ui/src/main/resources/static</directory>
+                        </fileset>
+                        <fileset>
                             <directory>db-scheduler-ui/src/main/resources/templates</directory>
                         </fileset>
                     </filesets>
@@ -335,10 +336,11 @@
                         <goals>
                             <goal>exec</goal>
                         </goals>
+                        <phase>generate-resources</phase>
                         <configuration>
                             <executable>npm</executable>
                             <arguments>
-                                <argument>install</argument>
+                                <argument>ci</argument>
                             </arguments>
                             <workingDirectory>./db-scheduler-ui-frontend</workingDirectory>
                         </configuration>
@@ -386,6 +388,24 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>clean-frontend</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <configuration>
+                            <filesets combine.children="append">
+                                <fileset>
+                                    <directory>db-scheduler-ui-frontend/node_modules</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>publication</id>
             <properties>


### PR DESCRIPTION
* Fix mvn exec `npm install`
    * Also `npm install` → `npm ci`
* Do not clean npm by default, explicit profile: `mvn clean install -Pclean-frontend`

---
This PR was prepared with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for frontend integration to optimize dependency installation and resource generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bekk/db-scheduler-ui/pull/156)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->