### PR TITLE
ci: drop Spring Boot 3.3, pin Boot 4 version, refresh patch versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spring-boot: [ '3.4.7', '3.5.3' ]
+        spring-boot: [ '3.4.13', '3.5.14' ]
 
     steps:
       - name: Checkout repo
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spring-boot-4: [ '4.0.2' ]
+        spring-boot-4: [ '4.0.6' ]
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spring-boot: [ '3.3.13', '3.4.7', '3.5.3' ]
+        spring-boot: [ '3.4.7', '3.5.3' ]
 
     steps:
       - name: Checkout repo
@@ -42,6 +42,9 @@ jobs:
   tests-boot4:
     name: Run tests with Spring Boot 4
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        spring-boot-4: [ '4.0.2' ]
 
     steps:
       - name: Checkout repo
@@ -70,4 +73,4 @@ jobs:
           distribution: 'temurin'
 
       - name: Run tests
-        run: mvn -B -pl db-scheduler-ui-spring-boot-4-starter,example-app-boot4 -am clean test --file pom.xml
+        run: mvn -B -Dspring-boot-4.version=${{ matrix.spring-boot-4 }} -pl db-scheduler-ui-spring-boot-4-starter,example-app-boot4 -am clean test --file pom.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,5 +66,5 @@ Multi-module Maven project (`pom.xml` at root):
 - Controllers are not annotated with `@Component` — they're instantiated as `@Bean` in `UiApiAutoConfiguration` so auto-configuration controls their lifecycle.
 - Java code uses Lombok (`@Data`, `@Builder`, etc.) and Google Java Format style.
 - All `.java`, `.ts`, `.tsx` source files (except tests) require Apache 2.0 license headers (enforced by `license-maven-plugin`).
-- CI tests against Spring Boot 3.3, 3.4, 3.5, and 4.0 for compatibility.
+- CI tests against Spring Boot 3.4, 3.5, and 4.0 for compatibility.
 - Frontend uses path alias `src` → `/src` (configured in vite.config.ts).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dashboard for monitoring and basic administration of tasks.
 
 * An existing Spring Boot application, with [db-scheduler](https://github.com/kagkarlsson/db-scheduler)
 * Minimum db-scheduler version 15
-* Minimum Java 17 and SpringBoot 3.3 (or SpringBoot 4.0 for the Spring Boot 4 starter)
+* Minimum Java 17 and SpringBoot 3.4 (or SpringBoot 4.0 for the Spring Boot 4 starter)
 * Optional (if you want task history): db-scheduler-log version 0.7.0
 
 ## Getting started


### PR DESCRIPTION
Update spring boot ci-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum Spring Boot version requirement from 3.3 to 3.4 in README
  * Updated CI compatibility guidance to reference Spring Boot 3.4, 3.5, and 4.0

* **Chores**
  * Updated CI workflow testing matrix to support Spring Boot 3.4.13, 3.5.14, and 4.0.6

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bekk/db-scheduler-ui/pull/166)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->