### PR TITLE
fix: uninvert caching condition

### DIFF
--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/util/Caching.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/util/Caching.java
@@ -35,7 +35,7 @@ public class Caching {
 
   public List<ScheduledExecution<Object>> getExecutionsFromCacheOrDB(
       boolean isRefresh, Scheduler scheduler) {
-    if (isRefresh || !taskDataCache.isEmpty()) {
+    if (isRefresh || taskDataCache.isEmpty()) {
       List<ScheduledExecution<Object>> executions =
           getExecutionsFromDBWithoutUpdatingCache(scheduler);
       updateCache(executions);

--- a/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/util/CachingTest.java
+++ b/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/util/CachingTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.bekk.dbscheduler.ui.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.kagkarlsson.scheduler.ScheduledExecution;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CachingTest {
+
+  private Caching caching;
+
+  @BeforeEach
+  void setUp() {
+    caching = new Caching();
+  }
+
+  @Test
+  void getExecutionsFromCacheOrDB_returnsCachedDataWhenPopulatedAndNoRefresh() {
+    TaskInstance<Object> taskInstance = new TaskInstance<>("my-task", "instance-1");
+    Execution execution = new Execution(Instant.now(), taskInstance);
+    ScheduledExecution<Object> scheduledExecution =
+        new ScheduledExecution<>(Object.class, execution);
+    caching.updateCache(List.of(scheduledExecution));
+
+    List<ScheduledExecution<Object>> result = caching.getExecutionsFromCacheOrDB(false, null);
+
+    assertThat(result)
+        .singleElement()
+        .satisfies(e -> assertThat(e.getTaskInstance().getTaskName()).isEqualTo("my-task"));
+  }
+}

--- a/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/util/CachingTest.java
+++ b/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/util/CachingTest.java
@@ -32,12 +32,17 @@ class CachingTest {
     caching = new Caching();
   }
 
+  private static ScheduledExecution<Object> buildScheduledExecution(
+      String taskName, String instanceId) {
+    TaskInstance<Object> taskInstance = new TaskInstance<>(taskName, instanceId);
+    Execution execution = new Execution(Instant.now(), taskInstance);
+    return new ScheduledExecution<>(Object.class, execution);
+  }
+
   @Test
   void getExecutionsFromCacheOrDB_returnsCachedDataWhenPopulatedAndNoRefresh() {
-    TaskInstance<Object> taskInstance = new TaskInstance<>("my-task", "instance-1");
-    Execution execution = new Execution(Instant.now(), taskInstance);
     ScheduledExecution<Object> scheduledExecution =
-        new ScheduledExecution<>(Object.class, execution);
+        buildScheduledExecution("my-task", "instance-1");
     caching.updateCache(List.of(scheduledExecution));
 
     List<ScheduledExecution<Object>> result = caching.getExecutionsFromCacheOrDB(false, null);

--- a/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/util/CachingTest.java
+++ b/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/util/CachingTest.java
@@ -32,6 +32,7 @@ class CachingTest {
     caching = new Caching();
   }
 
+  // TODO: Should be replaced by a constructor in the main product (db-scheduler)
   private static ScheduledExecution<Object> buildScheduledExecution(
       String taskName, String instanceId) {
     TaskInstance<Object> taskInstance = new TaskInstance<>(taskName, instanceId);


### PR DESCRIPTION
### Background

`Caching.getExecutionsFromCacheOrDB` condition is inverted, so the data is always fetched anew from the database, and never from cache. 

### Implementation

Removed the `!` from the if-condition. 

Also Added a unit test for the check, which fails before the fix was implemented, and succeeds after the fix. The test is written using AI, based on existing test patterns in the codebase. The test is checked by a human, but I am unsure of this specific code snippet:

``` java
TaskInstance<Object> taskInstance = new TaskInstance<>("my-task", "instance-1");
Execution execution = new Execution(Instant.now(), taskInstance);
ScheduledExecution<Object> scheduledExecution = new ScheduledExecution<>(Object.class, execution);
caching.updateCache(List.of(scheduledExecution));
```

### AI use

Claude Code, Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cache behavior so scheduled executions are loaded from the database when the cache is empty or when a refresh is requested, and returned from the cache when populated and no refresh is requested—preventing missing data and ensuring consistent results.

* **Tests**
  * Added test coverage verifying that cached execution data is returned when the cache is populated and no refresh is requested.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bekk/db-scheduler-ui/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->