### PR TITLE
chore: add explore-ui project skill and supporting ignores

### DIFF
--- a/.claude/skills/explore-ui/SKILL.md
+++ b/.claude/skills/explore-ui/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: explore-ui
+description: Launch the db-scheduler-ui in a browser to explore, screenshot, or verify UI changes. Use when running the app, taking screenshots of the dashboard, driving the UI with Playwright/Chromium, or confirming a frontend change works end-to-end. Covers both bundled-UI mode (one process) and Vite dev-server mode (frontend HMR).
+---
+
+# Explore the db-scheduler-ui in a browser
+
+Two launch modes. Pick by whether you need frontend hot-reload.
+
+## A. Backend only (bundled UI) — one process
+
+Fastest. Use when you only need to view/drive the UI, not edit the frontend.
+
+```bash
+./mvnw install -DskipTests -q                # once, to bundle frontend into the backend JAR
+(cd example-app && ../mvnw spring-boot:run)  # background; UI at http://localhost:8081/db-scheduler
+```
+
+- Trailing slash matters: `/db-scheduler` works, `/db-scheduler/` returns 404.
+- The bundle is built at `mvn install` time, not live — if you edit `db-scheduler-ui-frontend/`, use mode B instead.
+
+## B. Backend + Vite dev server — two processes
+
+Required for frontend HMR. The dev server proxies `/db-scheduler-api/**` to the backend.
+
+```bash
+(cd example-app && ../mvnw spring-boot:run)    # background; backend on :8081
+(cd db-scheduler-ui-frontend && pnpm run dev)  # background; dev server on :51373
+```
+
+Open `http://localhost:51373/`.
+
+## Readiness signals
+
+Wait for these before driving the UI — works with `until grep -q '...' <logfile>` or a Monitor:
+
+- **Backend ready:** `Started ExampleApp in N seconds`
+- **Dev server ready:** `VITE vX.Y.Z  ready in N ms` and `Local:   http://localhost:51373/`
+
+Backend startup is ~3s, dev server ~1s after deps are installed.
+
+## What you'll see
+
+The example-app pre-registers a mix of recurring, failing, long-running, and group-spawning tasks (see `example-app/src/main/java/.../tasks/`). The landing page is non-empty within a few seconds of startup — no seeding needed for screenshots or smoke checks.
+
+Key UI routes (both modes serve the same SPA):
+- `/` — "Scheduled" tab: all tasks with status, next-execution time, run/rerun controls
+- `/history/all` — "History" tab: execution log (requires `db-scheduler-ui.history=true`, which `example-app` sets)
+
+## Driving it
+
+Whatever headless browser is available — Playwright MCP (`mcp__playwright__browser_*`), `chromium-cli`, raw `curl` for API smoke. Same URLs above.
+
+Save screenshots under `.screenshots/` (gitignored) so they don't litter the repo root.
+
+## Common pitfalls
+
+- **404 at `/db-scheduler/`** (trailing slash): use `/db-scheduler` instead.
+- **Bundled UI shows stale content**: re-run `./mvnw install -DskipTests -q` — the bundle is a build artifact.
+- **API 404s like `/db-scheduler-api/all`**: paths are nested under resource, e.g. `/db-scheduler-api/tasks/all`, `/db-scheduler-api/logs/...`, `/db-scheduler-api/config`.
+- **Port already in use**: backend is `${PORT:8081}` (see `example-app/src/main/resources/application.properties`); dev server port is hard-coded to `51373` in `vite.config.ts`.

--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,13 @@ replay_pid*
 .sts4-cache
 .dbeaver
 
-# Claude
-.claude
+# Claude (personal overrides only — skills and shared settings stay tracked)
+.claude/settings.local.json
 
 # pnpm content-addressable store
 .pnpm-store/
+
+# Agent scratch dirs (browser snapshots, indexer caches)
+.screenshots/
+.playwright-mcp/
+.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,15 +59,17 @@ Notes:
 - If a change touches `db-scheduler-ui-frontend/`, drop `-Pfast` so the frontend actually rebuilds.
 - Always run `./mvnw spotless:apply` and `./mvnw license:format` before pushing — the full build fails without them.
 
+To launch the UI in a browser (screenshot, drive with Playwright, etc.), see the `explore-ui` project skill at `.claude/skills/explore-ui/SKILL.md`.
+
 ## Module Architecture
 
 Multi-module Maven project (`pom.xml` at root):
 
 - **db-scheduler-ui** — Core library. REST controllers (`/db-scheduler-api/**`), service logic (`TaskLogic`, `LogLogic`), query/filter/sort utilities, and task-to-model mapping. Contains the bundled frontend in `src/main/resources/static/`. No Spring Boot auto-configuration here — just plain Spring `@RestController` beans.
-  - `TaskController` (GET endpoints: `/all`, `/details`, `/poll`)
-  - `TaskAdminController` (POST endpoints: `/rerun`, `/rerunGroup`, `/delete`) — disabled when `read-only=true`
-  - `LogController` — task execution history (requires `history=true`)
-  - `ConfigController` — exposes UI config (history enabled, read-only mode)
+  - `TaskController` — `GET /db-scheduler-api/tasks/{all,details,poll}`
+  - `TaskAdminController` — `POST /db-scheduler-api/tasks/{rerun,rerunGroup,delete}`; disabled when `read-only=true`
+  - `LogController` — `GET /db-scheduler-api/logs/...`; requires `db-scheduler-ui.history=true`
+  - `ConfigController` — `GET /db-scheduler-api/config`; exposes UI config (history enabled, read-only mode)
   - `Caching` — in-memory cache of scheduler executions for polling/status changes
 
 - **db-scheduler-ui-starter** — Spring Boot 3 auto-configuration (`UiApiAutoConfiguration`). Wires up all beans from `db-scheduler-ui`, handles context-path/servlet-path resolution, SPA fallback routing, and index.html rewriting. Properties class: `DbSchedulerUiProperties`.


### PR DESCRIPTION
Adds a project-scoped skill that documents how to launch the example-app and drive the UI for screenshots or end-to-end checks, plus supporting tweaks so the skill is discoverable and agent scratch dirs stay out of the tree.

- New `.claude/skills/explore-ui/SKILL.md` covering bundled-UI and Vite dev-server launch modes
- `.gitignore`: stop ignoring the whole `.claude/` directory; ignore agent scratch dirs (`.screenshots/`, `.playwright-mcp/`, `.serena/`) and local-only Claude settings
- `CLAUDE.md`: pointer to the new skill and minor controller-route cleanups

---
This PR was prepared with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for launching the scheduler UI in a browser, covering setup modes, expected URLs, readiness signals, and common troubleshooting tips.
  * Expanded module architecture documentation with explicit endpoint patterns and feature flag configurations.

* **Chores**
  * Updated version control configuration to exclude additional development artifacts and runtime caches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bekk/db-scheduler-ui/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->