### PR TITLE
fix: serve SPA fallback without FileNotFoundException on lastModified

### DIFF
--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/SpaFallbackMvc.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/SpaFallbackMvc.java
@@ -62,7 +62,14 @@ public class SpaFallbackMvc implements WebMvcConfigurer {
         return requestedResource;
       }
 
-      return new ByteArrayResource(indexHtml.getBytes(StandardCharsets.UTF_8));
+      // ByteArrayResource has no backing file, so override lastModified() to avoid
+      // FileNotFoundException
+      return new ByteArrayResource(indexHtml.getBytes(StandardCharsets.UTF_8)) {
+        @Override
+        public long lastModified() {
+          return -1;
+        }
+      };
     }
   }
 }

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
@@ -79,6 +79,17 @@ class SmokeTest {
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
+  // Regression test for
+  // issue #149: the ByteArrayResource fallback threw FileNotFoundException on lastModified(),
+  // returning 500 instead of the SPA shell.
+  @Test
+  void unknownSpaRouteServesIndexHtml() {
+    ResponseEntity<String> result =
+        this.restTemplate.getForEntity(baseUrl + "/db-scheduler/some-spa-route", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).contains("/db-scheduler");
+  }
+
   @BeforeEach
   void setUp() {
     baseUrl = "http://localhost:" + serverPort;


### PR DESCRIPTION
Since 4.5.6, SPA deep-links that aren't hardcoded routes returned HTTP 500. The fallback served the index shell as a `ByteArrayResource`, which has no file, so Spring throws `FileNotFoundException` when it reads `lastModified()` for the `Last-Modified` header. Fixes #149.

- Override lastModified() on the SPA fallback resource to return -1 (unknown) so the shell is served instead of erroring
- Add a regression test covering an unknown SPA deep-link

---
This PR was prepared with Claude Code.