### PR TITLE
fix: debounce task name/id search inputs (#119)

### DIFF
--- a/db-scheduler-ui-frontend/src/components/common/HeaderBar.tsx
+++ b/db-scheduler-ui-frontend/src/components/common/HeaderBar.tsx
@@ -35,6 +35,7 @@ import colors from 'src/styles/colors';
 import { RunAllAlert } from 'src/components/scheduled/RunAllAlert';
 import { TaskDetailsRequestParams } from 'src/models/TaskRequestParams';
 import { useParams } from 'react-router-dom';
+import { useDebouncedCallback } from 'src/hooks/useDebouncedCallback';
 
 interface HeaderBarProps {
   params: TaskDetailsRequestParams;
@@ -69,6 +70,12 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({
   const isDetailsView = !!urlTaskName;
   const [isOpen, setIsOpen] = React.useState('');
   const { taskName, taskId: taskInstance, filter: currentFilter } = params;
+  const debouncedSetSearchTermTaskName = useDebouncedCallback(
+    setSearchTermTaskName,
+  );
+  const debouncedSetSearchTermTaskInstance = useDebouncedCallback(
+    setSearchTermTaskInstance,
+  );
 
   return (
     <Box
@@ -130,7 +137,9 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({
                 <Input
                   placeholder={'Search for task name'}
                   defaultValue={taskName}
-                  onChange={(e) => setSearchTermTaskName(e.currentTarget.value)}
+                  onChange={(e) =>
+                    debouncedSetSearchTermTaskName(e.currentTarget.value)
+                  }
                   bgColor={colors.primary['100']}
                   w={'20vmax'}
                   mt={7}
@@ -159,7 +168,7 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({
                 placeholder={'Search for task id'}
                 defaultValue={taskInstance}
                 onChange={(e) =>
-                  setSearchTermTaskInstance(e.currentTarget.value)
+                  debouncedSetSearchTermTaskInstance(e.currentTarget.value)
                 }
                 bgColor={colors.primary['100']}
                 w={'20vmax'}

--- a/db-scheduler-ui-frontend/src/hooks/useDebouncedCallback.ts
+++ b/db-scheduler-ui-frontend/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+
+/**
+ * Returns a debounced version of `callback` that only fires once `delay`
+ * milliseconds have elapsed since the last invocation. Useful for avoiding a
+ * request on every keystroke when filtering by a search term.
+ */
+export const useDebouncedCallback = <A extends unknown[]>(
+  callback: (...args: A) => void,
+  delay = 300,
+) => {
+  const callbackRef = useRef(callback);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  return useMemo(
+    () =>
+      (...args: A) => {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => {
+          callbackRef.current(...args);
+        }, delay);
+      },
+    [delay],
+  );
+};


### PR DESCRIPTION
The history and scheduled views fired an API request on every keystroke when filtering by task name or id, since the search term feeds the React Query key directly. This debounces the search-term update so a request is only issued once typing pauses. Fixes #119.

- Add a `useDebouncedCallback` hook (300ms) for debouncing setter calls
- Wire both search inputs in `HeaderBar` through the debounced setters; inputs stay uncontrolled so typed text remains instant

---
This PR was prepared with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search functionality now debounces input updates, reducing unnecessary queries while typing for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->