### PR TITLE
Implement overview page behind feature toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ dashboard for monitoring and basic administration of tasks.
 ### Prerequisites
 
 * An existing Spring Boot application, with [db-scheduler](https://github.com/kagkarlsson/db-scheduler)
-* Minimum db-scheduler version 16
+* Minimum db-scheduler version 16.12.0
 * Minimum Java 17 and SpringBoot 3.4 (or SpringBoot 4.0 for the Spring Boot 4 starter)
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ dashboard for monitoring and basic administration of tasks.
 ### Prerequisites
 
 * An existing Spring Boot application, with [db-scheduler](https://github.com/kagkarlsson/db-scheduler)
-* Minimum db-scheduler version 15
+* Minimum db-scheduler version 16
 * Minimum Java 17 and SpringBoot 3.4 (or SpringBoot 4.0 for the Spring Boot 4 starter)
 
 ## Getting started
@@ -177,7 +177,7 @@ additionally you might want to hide delete, run, ... buttons in the UI. To achie
 ```java
 @Bean
 ConfigController configController(DbSchedulerUiProperties properties) {
-  return new ConfigController(properties.isHistory(), readOnly(properties));
+  return new ConfigController(properties.isHistory(), properties.isOverview(), readOnly(properties));
 }
 
 private Supplier<Boolean> readOnly(DbSchedulerUiProperties properties) {

--- a/db-scheduler-ui-frontend/src/components/common/TopBar.tsx
+++ b/db-scheduler-ui-frontend/src/components/common/TopBar.tsx
@@ -28,7 +28,7 @@ export const TopBar: React.FC<TopBarProps> = ({ title }) => {
   const showHistory = getShowHistory();
   const showOverview = getShowOverview();
   const showNavigation = showOverview || showHistory;
-  const isHistory = location.pathname.includes('/history');
+  const isHistory = location.pathname.startsWith('/history');
   const isOverview = showOverview && location.pathname === '/';
   const isScheduled = !isHistory && !isOverview;
   const scheduledPath = showOverview ? '/scheduled' : '/';

--- a/db-scheduler-ui-frontend/src/components/common/TopBar.tsx
+++ b/db-scheduler-ui-frontend/src/components/common/TopBar.tsx
@@ -29,7 +29,7 @@ export const TopBar: React.FC<TopBarProps> = ({ title }) => {
   const showOverview = getShowOverview();
   const showNavigation = showOverview || showHistory;
   const isHistory = location.pathname.startsWith('/history');
-  const isOverview = showOverview && location.pathname === '/';
+  const isOverview = showOverview && location.pathname === '/overview';
   const isScheduled = !isHistory && !isOverview;
   const scheduledPath = showOverview ? '/scheduled' : '/';
 
@@ -113,7 +113,7 @@ export const TopBar: React.FC<TopBarProps> = ({ title }) => {
                 borderBottom="2px"
                 borderRadius={'0'}
                 borderColor={isOverview ? colors.dbBlue : colors.primary['300']}
-                onClick={() => navigate('/')}
+                onClick={() => navigate('/overview')}
                 aria-label={'Overview button'}
               >
                 Overview

--- a/db-scheduler-ui-frontend/src/components/common/TopBar.tsx
+++ b/db-scheduler-ui-frontend/src/components/common/TopBar.tsx
@@ -13,10 +13,10 @@
  */
 import { Box, Button, Text } from '@chakra-ui/react';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { LogoIcon } from 'src/assets/icons/Logo';
 import colors from 'src/styles/colors';
-import { getShowHistory } from 'src/utils/config';
+import { getShowHistory, getShowOverview } from 'src/utils/config';
 
 interface TopBarProps {
   title: string;
@@ -24,7 +24,14 @@ interface TopBarProps {
 
 export const TopBar: React.FC<TopBarProps> = ({ title }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const showHistory = getShowHistory();
+  const showOverview = getShowOverview();
+  const showNavigation = showOverview || showHistory;
+  const isHistory = location.pathname.includes('/history');
+  const isOverview = showOverview && location.pathname === '/';
+  const isScheduled = !isHistory && !isOverview;
+  const scheduledPath = showOverview ? '/scheduled' : '/';
 
   return (
     <Box
@@ -45,8 +52,8 @@ export const TopBar: React.FC<TopBarProps> = ({ title }) => {
         <LogoIcon mr={2} />
         {title}
       </Text>
-      <Box>
-        {showHistory && (
+      <Box display={'flex'} alignItems={'center'} gap={12} flexShrink={0}>
+        {showNavigation && (
           <>
             <Button
               _hover={{
@@ -62,41 +69,56 @@ export const TopBar: React.FC<TopBarProps> = ({ title }) => {
               color={colors.dbBlue}
               borderBottom="2px"
               borderRadius={'0'}
-              borderColor={
-                !window.location.toString().includes('db-scheduler/history/')
-                  ? colors.dbBlue
-                  : colors.primary['300']
-              }
-              onClick={() => navigate('/')}
-              aria-label={'Home button'}
-              marginRight={12}
+              borderColor={isScheduled ? colors.dbBlue : colors.primary['300']}
+              onClick={() => navigate(scheduledPath)}
+              aria-label={'Scheduled button'}
             >
               Scheduled
             </Button>
-            <Button
-              _hover={{
-                bgColor: colors.primary['100'],
-                borderColor: colors.dbBlue,
-                color: colors.primary['400'],
-              }}
-              _active={{
-                borderColor: colors.running['200'],
-                color: colors.primary['300'],
-              }}
-              bgColor={colors.primary['100']}
-              color={colors.dbBlue}
-              borderBottom="2px"
-              borderRadius={'0'}
-              borderColor={
-                window.location.toString().includes('history')
-                  ? colors.dbBlue
-                  : colors.primary['300']
-              }
-              onClick={() => navigate(`/history/all`)}
-              aria-label={'History button'}
-            >
-              History
-            </Button>
+            {showHistory && (
+              <Button
+                _hover={{
+                  bgColor: colors.primary['100'],
+                  borderColor: colors.dbBlue,
+                  color: colors.primary['400'],
+                }}
+                _active={{
+                  borderColor: colors.running['200'],
+                  color: colors.primary['300'],
+                }}
+                bgColor={colors.primary['100']}
+                color={colors.dbBlue}
+                borderBottom="2px"
+                borderRadius={'0'}
+                borderColor={isHistory ? colors.dbBlue : colors.primary['300']}
+                onClick={() => navigate(`/history/all`)}
+                aria-label={'History button'}
+              >
+                History
+              </Button>
+            )}
+            {showOverview && (
+              <Button
+                _hover={{
+                  bgColor: colors.primary['100'],
+                  borderColor: colors.dbBlue,
+                  color: colors.primary['400'],
+                }}
+                _active={{
+                  borderColor: colors.primary['200'],
+                  color: colors.primary['300'],
+                }}
+                bgColor={colors.primary['100']}
+                color={colors.dbBlue}
+                borderBottom="2px"
+                borderRadius={'0'}
+                borderColor={isOverview ? colors.dbBlue : colors.primary['300']}
+                onClick={() => navigate('/')}
+                aria-label={'Overview button'}
+              >
+                Overview
+              </Button>
+            )}
           </>
         )}
       </Box>

--- a/db-scheduler-ui-frontend/src/models/OverviewTask.ts
+++ b/db-scheduler-ui-frontend/src/models/OverviewTask.ts
@@ -11,17 +11,26 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package no.bekk.dbscheduler.ui.model;
+export type OverviewTaskStatus =
+  | 'FAILING'
+  | 'RUNNING'
+  | 'SCHEDULED'
+  | 'DORMANT';
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+export type OverviewTaskCounts = {
+  failing: number;
+  running: number;
+  scheduled: number;
+};
 
-@Getter
-@Setter
-@AllArgsConstructor
-public class ConfigResponse {
-  private boolean showHistory;
-  private boolean showOverview;
-  private boolean readOnly;
-}
+export type OverviewTask = {
+  taskName: string;
+  recurring: boolean | null;
+  instanceCount: number;
+  counts: OverviewTaskCounts;
+  worstStatus: OverviewTaskStatus;
+  nextExecutionTime: string | null;
+  lastSuccess: string | null;
+  lastFailure: string | null;
+  maxConsecutiveFailures: number;
+};

--- a/db-scheduler-ui-frontend/src/pages/FrontPage.tsx
+++ b/db-scheduler-ui-frontend/src/pages/FrontPage.tsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 import { Box } from '@chakra-ui/react';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { TopBar } from 'src/components/common/TopBar';
 import { LogList } from 'src/components/history/LogList';
 import TaskList from 'src/components/scheduled/TaskList';
@@ -29,10 +29,11 @@ export const FrontPage: React.FC = () => {
         <Routes>
           <Route
             index
-            element={showOverview ? <OverviewPage /> : <TaskList />}
+            element={showOverview ? <Navigate to="/overview" replace /> : <TaskList />}
           ></Route>
           {showOverview && (
             <>
+              <Route path="/overview" element={<OverviewPage />}></Route>
               <Route path="/scheduled" element={<TaskList />}></Route>
               <Route path="/scheduled/:taskName" element={<TaskList />}></Route>
               <Route

--- a/db-scheduler-ui-frontend/src/pages/FrontPage.tsx
+++ b/db-scheduler-ui-frontend/src/pages/FrontPage.tsx
@@ -16,16 +16,31 @@ import { Route, Routes } from 'react-router-dom';
 import { TopBar } from 'src/components/common/TopBar';
 import { LogList } from 'src/components/history/LogList';
 import TaskList from 'src/components/scheduled/TaskList';
-import { getShowHistory } from 'src/utils/config';
+import { OverviewPage } from 'src/pages/OverviewPage';
+import { getShowHistory, getShowOverview } from 'src/utils/config';
 
 export const FrontPage: React.FC = () => {
   const showHistory = getShowHistory();
+  const showOverview = getShowOverview();
   return (
     <>
       <TopBar title={'DB Scheduler UI'} />
       <Box mx={20} mt={14}>
         <Routes>
-          <Route index element={<TaskList />}></Route>
+          <Route
+            index
+            element={showOverview ? <OverviewPage /> : <TaskList />}
+          ></Route>
+          {showOverview && (
+            <>
+              <Route path="/scheduled" element={<TaskList />}></Route>
+              <Route path="/scheduled/:taskName" element={<TaskList />}></Route>
+              <Route
+                path="/scheduled/:taskName/page/:page"
+                element={<TaskList />}
+              ></Route>
+            </>
+          )}
           <Route path="/:taskName" element={<TaskList />}></Route>
           <Route path="/:taskName/page/:page" element={<TaskList />}></Route>
           <Route

--- a/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
+++ b/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Box,
+  HStack,
+  Link,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react';
+import { ArrowForwardIcon } from '@chakra-ui/icons';
+import { useQuery } from '@tanstack/react-query';
+import { OverviewTask, OverviewTaskStatus } from 'src/models/OverviewTask';
+import {
+  getOverviewTasks,
+  OVERVIEW_TASKS_QUERY_KEY,
+} from 'src/services/getOverviewTasks';
+import colors from 'src/styles/colors';
+import { dateFormatText } from 'src/utils/dateFormatText';
+import {
+  formatDistanceStrict,
+  formatDistanceToNowStrict,
+  isBefore,
+} from 'date-fns';
+import { Link as RouterLink } from 'react-router-dom';
+
+const statusText: Record<OverviewTaskStatus, string> = {
+  FAILING: 'failing',
+  RUNNING: 'running',
+  SCHEDULED: 'scheduled',
+  DORMANT: 'dormant',
+};
+
+const statusColors: Record<OverviewTaskStatus, string> = {
+  FAILING: colors.failed['200'],
+  RUNNING: colors.running['300'],
+  SCHEDULED: colors.success['200'],
+  DORMANT: colors.primary['400'],
+};
+
+const overdueColor = '#725200';
+
+export const OverviewPage: React.FC = () => {
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useQuery([OVERVIEW_TASKS_QUERY_KEY], getOverviewTasks);
+
+  const recurringTasks = sorted(data.filter((task) => task.recurring === true));
+  const customTasks = sorted(data.filter((task) => task.recurring !== true));
+
+  return (
+    <Box>
+      <Text ml={1} mb={7} fontSize={'3xl'} fontWeight={'semibold'}>
+        All tasks
+      </Text>
+      <TableContainer overflowX="auto">
+        <Table
+          variant="simple"
+          size="md"
+          sx={{ borderCollapse: 'separate', borderSpacing: '0 8px' }}
+        >
+          <Thead>
+            <Tr>
+              <Th borderBottomColor={colors.primary['300']}>Task</Th>
+              <Th width="18%">Next run</Th>
+              <Th width="18%">Last run</Th>
+              <Th width="10%"></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {isLoading && <MessageRow message="Loading tasks" />}
+            {isError && <MessageRow message="Could not load tasks" />}
+            {!isLoading && !isError && (
+              <>
+                <SectionHeader
+                  title="Recurring"
+                  count={recurringTasks.length}
+                />
+                {recurringTasks.map((task) => (
+                  <OverviewRow key={task.taskName} task={task} />
+                ))}
+                <SectionHeader
+                  title="One-time / custom"
+                  count={customTasks.length}
+                />
+                {customTasks.map((task) => (
+                  <OverviewRow key={task.taskName} task={task} />
+                ))}
+              </>
+            )}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+const SectionHeader: React.FC<{ title: string; count: number }> = ({
+  title,
+  count,
+}) => (
+  <Tr>
+    <Td colSpan={4} borderBottom="none" pb={0} pt={3}>
+      <Text
+        textTransform="uppercase"
+        color={colors.primary['500']}
+        fontWeight="bold"
+        fontSize="sm"
+      >
+        {title} · {count}
+      </Text>
+    </Td>
+  </Tr>
+);
+
+const OverviewRow: React.FC<{ task: OverviewTask }> = ({ task }) => {
+  const drillDownTarget =
+    task.instanceCount === 1
+      ? `/scheduled/${encodeURIComponent(task.taskName)}`
+      : `/scheduled/${encodeURIComponent(task.taskName)}`;
+  const drillDownLabel = task.instanceCount === 1 ? 'instance' : 'list';
+
+  return (
+    <Tr sx={rowSx(task)}>
+      <Td>
+        <HStack align="start" spacing={3}>
+          <Box
+            aria-hidden="true"
+            bgColor={dotColor(task.worstStatus)}
+            borderRadius="50%"
+            flexShrink={0}
+            height="0.75rem"
+            mt={2}
+            width="0.75rem"
+          />
+          <Box minW={0}>
+            <HStack spacing={2}>
+              <Text fontWeight="bold">{task.taskName}</Text>
+              <Text
+                color={statusColors[task.worstStatus]}
+                fontWeight="semibold"
+              >
+                {statusText[task.worstStatus]}
+              </Text>
+            </HStack>
+            <Box color={colors.primary['400']} fontSize="sm">
+              {subLine(task)}
+            </Box>
+          </Box>
+        </HStack>
+      </Td>
+      <Td>
+        <Text
+          title={absoluteTitle(task.nextExecutionTime)}
+          color={isOverdue(task) ? overdueColor : colors.primary['500']}
+          fontWeight={
+            isOverdue(task) || task.counts.running > 0 ? 'semibold' : 'normal'
+          }
+        >
+          {nextRunText(task)}
+        </Text>
+      </Td>
+      <Td>{lastRunText(task)}</Td>
+      <Td textAlign="right">
+        {task.instanceCount > 0 && (
+          <Link
+            as={RouterLink}
+            to={drillDownTarget}
+            color={colors.dbBlue}
+            fontWeight="semibold"
+            whiteSpace="nowrap"
+          >
+            <ArrowForwardIcon aria-hidden="true" /> {drillDownLabel}
+          </Link>
+        )}
+      </Td>
+    </Tr>
+  );
+};
+
+const MessageRow: React.FC<{ message: string }> = ({ message }) => (
+  <Tr>
+    <Td colSpan={4}>
+      <Text color={colors.primary['400']}>{message}</Text>
+    </Td>
+  </Tr>
+);
+
+function sorted(tasks: OverviewTask[]): OverviewTask[] {
+  return [...tasks].sort((a, b) => a.taskName.localeCompare(b.taskName));
+}
+
+function subLine(task: OverviewTask) {
+  if (task.instanceCount > 1 && task.recurring !== true) {
+    return (
+      <HStack spacing={1} flexWrap="wrap">
+        <Text as="span">{instancesText(task.instanceCount)}</Text>
+        {countPart(task.counts.failing, 'failing', colors.failed['200'])}
+        {countPart(task.counts.running, 'running', colors.running['300'])}
+        {countPart(task.counts.scheduled, 'scheduled', colors.primary['500'])}
+      </HStack>
+    );
+  }
+
+  const base = statusText[task.worstStatus];
+  const duration = statusDuration(task);
+  const parts = [duration ? `${base} for ${duration}` : base];
+
+  if (task.recurring !== true) {
+    parts.push(instancesText(task.instanceCount));
+  }
+
+  return parts.join(' · ');
+}
+
+function statusDuration(task: OverviewTask): string | null {
+  if (task.worstStatus === 'FAILING' && task.lastSuccess) {
+    return formatDistanceStrict(new Date(task.lastSuccess), new Date());
+  }
+
+  if (
+    task.worstStatus === 'RUNNING' &&
+    task.instanceCount === 1 &&
+    task.nextExecutionTime
+  ) {
+    return formatDistanceStrict(new Date(task.nextExecutionTime), new Date());
+  }
+
+  return null;
+}
+
+function nextRunText(task: OverviewTask): string {
+  if (task.worstStatus === 'DORMANT' || !task.nextExecutionTime) {
+    return '-';
+  }
+
+  if (task.counts.running > 0) {
+    return 'running now';
+  }
+
+  const date = new Date(task.nextExecutionTime);
+  const distance = formatDistanceToNowStrict(date);
+  return isBefore(date, new Date()) ? `due ${distance} ago` : `in ${distance}`;
+}
+
+function lastRunText(task: OverviewTask) {
+  const lastSuccess = parseDate(task.lastSuccess);
+  const lastFailure = parseDate(task.lastFailure);
+
+  if (!lastSuccess && !lastFailure) {
+    return <Text color={colors.primary['400']}>never run</Text>;
+  }
+
+  const lastWasFailure =
+    lastFailure !== null && (lastSuccess === null || lastFailure > lastSuccess);
+  const date = lastWasFailure ? lastFailure : lastSuccess;
+
+  if (!date) {
+    return <Text color={colors.primary['400']}>never run</Text>;
+  }
+
+  return (
+    <Text
+      title={dateFormatText(date)}
+      color={lastWasFailure ? colors.failed['200'] : colors.success['200']}
+      fontWeight="semibold"
+    >
+      {lastWasFailure ? 'last failure' : 'last success'}{' '}
+      {formatDistanceToNowStrict(date, { addSuffix: true })}
+    </Text>
+  );
+}
+
+function parseDate(value: string | null): Date | null {
+  return value ? new Date(value) : null;
+}
+
+function absoluteTitle(value: string | null): string | undefined {
+  return value ? dateFormatText(new Date(value)) : undefined;
+}
+
+function isOverdue(task: OverviewTask): boolean {
+  return (
+    task.counts.running === 0 &&
+    !!task.nextExecutionTime &&
+    isBefore(new Date(task.nextExecutionTime), new Date())
+  );
+}
+
+function instancesText(count: number): string {
+  return `${count} ${count === 1 ? 'instance' : 'instances'}`;
+}
+
+function countPart(count: number, label: string, color: string) {
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Text as="span">·</Text>
+      <Text as="span" color={color} fontWeight="semibold">
+        {count} {label}
+      </Text>
+    </>
+  );
+}
+
+function rowBackground(task: OverviewTask): string | undefined {
+  if (task.worstStatus === 'FAILING') {
+    return colors.failed['100'];
+  }
+  if (task.worstStatus === 'RUNNING') {
+    return colors.running['100'];
+  }
+  return colors.primary['100'];
+}
+
+function rowBorderColor(task: OverviewTask): string {
+  if (task.worstStatus === 'FAILING') {
+    return '#f7b8b8';
+  }
+  if (task.worstStatus === 'RUNNING') {
+    return colors.running['200'];
+  }
+  return colors.primary['300'];
+}
+
+function dotColor(status: OverviewTaskStatus): string {
+  if (status === 'SCHEDULED') {
+    return '#cfd6dc';
+  }
+  return statusColors[status];
+}
+
+function rowSx(task: OverviewTask) {
+  return {
+    '& > td': {
+      bgColor: rowBackground(task),
+      borderBottom: '1px solid',
+      borderBottomColor: rowBorderColor(task),
+      borderTop: '1px solid',
+      borderTopColor: rowBorderColor(task),
+      py: 4,
+    },
+    '& > td:first-of-type': {
+      borderLeft: '1px solid',
+      borderLeftColor: rowBorderColor(task),
+      borderBottomLeftRadius: '8px',
+      borderTopLeftRadius: '8px',
+    },
+    '& > td:last-of-type': {
+      borderRight: '1px solid',
+      borderRightColor: rowBorderColor(task),
+      borderBottomRightRadius: '8px',
+      borderTopRightRadius: '8px',
+    },
+  };
+}

--- a/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
+++ b/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
@@ -139,14 +139,13 @@ const OverviewRow: React.FC<{ task: OverviewTask }> = ({ task }) => {
       cursor={task.instanceCount > 0 ? 'pointer' : 'default'}
     >
       <Td>
-        <HStack align="start" spacing={3}>
+        <HStack align="center" spacing={3}>
           <Box
             aria-hidden="true"
             bgColor={dotColor(task.worstStatus)}
             borderRadius="50%"
             flexShrink={0}
             height="0.75rem"
-            mt={2}
             width="0.75rem"
           />
           <Box minW={0}>

--- a/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
+++ b/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
@@ -115,7 +115,7 @@ const SectionHeader: React.FC<{ title: string; count: number }> = ({
   count,
 }) => (
   <Tr>
-    <Td colSpan={4} borderBottom="none" pb={0} pt={3}>
+    <Td colSpan={3} borderBottom="none" pb={0} pt={3}>
       <Text
         textTransform="uppercase"
         color={colors.primary['500']}
@@ -183,7 +183,7 @@ const OverviewRow: React.FC<{ task: OverviewTask }> = ({ task }) => {
 
 const MessageRow: React.FC<{ message: string }> = ({ message }) => (
   <Tr>
-    <Td colSpan={4}>
+    <Td colSpan={3}>
       <Text color={colors.primary['400']}>{message}</Text>
     </Td>
   </Tr>

--- a/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
+++ b/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
@@ -14,7 +14,6 @@
 import {
   Box,
   HStack,
-  Link,
   Table,
   TableContainer,
   Tbody,
@@ -24,7 +23,6 @@ import {
   Thead,
   Tr,
 } from '@chakra-ui/react';
-import { ArrowForwardIcon } from '@chakra-ui/icons';
 import { useQuery } from '@tanstack/react-query';
 import { OverviewTask, OverviewTaskStatus } from 'src/models/OverviewTask';
 import {
@@ -38,7 +36,7 @@ import {
   formatDistanceToNowStrict,
   isBefore,
 } from 'date-fns';
-import { Link as RouterLink } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const statusText: Record<OverviewTaskStatus, string> = {
   FAILING: 'failing',
@@ -82,7 +80,6 @@ export const OverviewPage: React.FC = () => {
               <Th>Task</Th>
               <Th width="18%">Next run</Th>
               <Th width="18%">Last run</Th>
-              <Th width="10%"></Th>
             </Tr>
           </Thead>
           <Tbody>
@@ -132,14 +129,15 @@ const SectionHeader: React.FC<{ title: string; count: number }> = ({
 );
 
 const OverviewRow: React.FC<{ task: OverviewTask }> = ({ task }) => {
-  const drillDownTarget =
-    task.instanceCount === 1
-      ? `/scheduled/${encodeURIComponent(task.taskName)}`
-      : `/scheduled/${encodeURIComponent(task.taskName)}`;
-  const drillDownLabel = task.instanceCount === 1 ? 'instance' : 'list';
+  const navigate = useNavigate();
+  const drillDownTarget = `/scheduled/${encodeURIComponent(task.taskName)}`;
 
   return (
-    <Tr sx={rowSx(task)}>
+    <Tr
+      sx={rowSx(task, task.instanceCount > 0)}
+      onClick={() => task.instanceCount > 0 && navigate(drillDownTarget)}
+      cursor={task.instanceCount > 0 ? 'pointer' : 'default'}
+    >
       <Td>
         <HStack align="start" spacing={3}>
           <Box
@@ -179,19 +177,6 @@ const OverviewRow: React.FC<{ task: OverviewTask }> = ({ task }) => {
         </Text>
       </Td>
       <Td>{lastRunText(task)}</Td>
-      <Td textAlign="right">
-        {task.instanceCount > 0 && (
-          <Link
-            as={RouterLink}
-            to={drillDownTarget}
-            color={colors.dbBlue}
-            fontWeight="semibold"
-            whiteSpace="nowrap"
-          >
-            <ArrowForwardIcon aria-hidden="true" /> {drillDownLabel}
-          </Link>
-        )}
-      </Td>
     </Tr>
   );
 };
@@ -334,6 +319,16 @@ function rowBackground(task: OverviewTask): string | undefined {
   return colors.primary['100'];
 }
 
+function rowHoverBackground(task: OverviewTask): string {
+  if (task.worstStatus === 'FAILING') {
+    return '#e5b0b0';
+  }
+  if (task.worstStatus === 'RUNNING') {
+    return colors.running['200'];
+  }
+  return colors.primary['200'];
+}
+
 function rowBorderColor(task: OverviewTask): string {
   if (task.worstStatus === 'FAILING') {
     return '#f7b8b8';
@@ -351,7 +346,7 @@ function dotColor(status: OverviewTaskStatus): string {
   return statusColors[status];
 }
 
-function rowSx(task: OverviewTask) {
+function rowSx(task: OverviewTask, clickable = false) {
   return {
     '& > td': {
       bgColor: rowBackground(task),
@@ -360,6 +355,7 @@ function rowSx(task: OverviewTask) {
       borderTop: '1px solid',
       borderTopColor: rowBorderColor(task),
       py: 4,
+      transition: 'background-color 0.12s ease',
     },
     '& > td:first-of-type': {
       borderLeft: '1px solid',
@@ -373,5 +369,10 @@ function rowSx(task: OverviewTask) {
       borderBottomRightRadius: '8px',
       borderTopRightRadius: '8px',
     },
+    ...(clickable && {
+      transition: 'filter 0.12s ease',
+      '&:hover > td': { bgColor: rowHoverBackground(task) },
+      '&:hover': { filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.12))' },
+    }),
   };
 }

--- a/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
+++ b/db-scheduler-ui-frontend/src/pages/OverviewPage.tsx
@@ -77,9 +77,9 @@ export const OverviewPage: React.FC = () => {
           size="md"
           sx={{ borderCollapse: 'separate', borderSpacing: '0 8px' }}
         >
-          <Thead>
+          <Thead sx={{ th: { borderBottomColor: colors.primary['300'] } }}>
             <Tr>
-              <Th borderBottomColor={colors.primary['300']}>Task</Th>
+              <Th>Task</Th>
               <Th width="18%">Next run</Th>
               <Th width="18%">Last run</Th>
               <Th width="10%"></Th>

--- a/db-scheduler-ui-frontend/src/services/getOverviewTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/getOverviewTasks.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OverviewTask } from 'src/models/OverviewTask';
+
+const API_BASE_URL: string =
+  (import.meta.env.VITE_API_BASE_URL as string) ??
+  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+
+export const OVERVIEW_TASKS_QUERY_KEY = 'overviewTasks';
+
+export const getOverviewTasks = async (): Promise<OverviewTask[]> => {
+  const response = await fetch(`${API_BASE_URL}/tasks/overview`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (response.status == 401) {
+    document.location.href = '/db-scheduler';
+  } else if (!response.ok) {
+    throw new Error(
+      `Error fetching overview tasks. Status: ${response.statusText}`,
+    );
+  }
+
+  return await response.json();
+};

--- a/db-scheduler-ui-frontend/src/services/getOverviewTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/getOverviewTasks.ts
@@ -27,7 +27,7 @@ export const getOverviewTasks = async (): Promise<OverviewTask[]> => {
     },
   });
 
-  if (response.status == 401) {
+  if (response.status === 401) {
     document.location.href = '/db-scheduler';
   } else if (!response.ok) {
     throw new Error(

--- a/db-scheduler-ui-frontend/src/utils/config.ts
+++ b/db-scheduler-ui-frontend/src/utils/config.ts
@@ -23,7 +23,11 @@ const config = await fetch(`${API_BASE_URL}/config`).then((res) =>
 const showHistory =
   'showHistory' in config ? Boolean(config.showHistory) : false;
 
+const showOverview =
+  'showOverview' in config ? Boolean(config.showOverview) : false;
+
 const readOnly = 'readOnly' in config ? Boolean(config.readOnly) : false;
 
 export const getShowHistory = (): boolean => showHistory;
+export const getShowOverview = (): boolean => showOverview;
 export const getReadonly = (): boolean => readOnly;

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -19,22 +19,26 @@ import static no.bekk.dbscheduler.uistarter.config.DbSchedulerUiUtil.normalizePa
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
+import com.github.kagkarlsson.scheduler.task.Task;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import javax.sql.DataSource;
 import no.bekk.dbscheduler.ui.controller.ConfigController;
 import no.bekk.dbscheduler.ui.controller.IndexHtmlController;
 import no.bekk.dbscheduler.ui.controller.LogController;
+import no.bekk.dbscheduler.ui.controller.OverviewController;
 import no.bekk.dbscheduler.ui.controller.SpaFallbackMvc;
 import no.bekk.dbscheduler.ui.controller.TaskAdminController;
 import no.bekk.dbscheduler.ui.controller.TaskController;
 import no.bekk.dbscheduler.ui.service.LogLogic;
+import no.bekk.dbscheduler.ui.service.OverviewService;
 import no.bekk.dbscheduler.ui.service.TaskLogic;
 import no.bekk.dbscheduler.ui.util.Caching;
 import no.bekk.dbscheduler.uistarter.config.DbSchedulerUiProperties;
 import no.bekk.dbscheduler.uistarter.config.DbSchedulerUiWebConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -62,9 +66,10 @@ public class UiApiAutoConfiguration {
   private final String dbSchedulerContextPath;
 
   UiApiAutoConfiguration(
-      @Value("${server.servlet.context-path:}") String servletContextPath,
-      @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
-      @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath) {
+    @Value("${server.servlet.context-path:}") String servletContextPath,
+    @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
+    @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath
+  ) {
     logger.info("UiApiAutoConfiguration created");
     this.servletContextPath = normalizePaths(servletContextPath);
     this.dbSchedulerContextPath = normalizePaths(dbSchedulerContextPath);
@@ -85,34 +90,34 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(
-      prefix = "db-scheduler-ui",
-      name = "history",
-      havingValue = "true",
-      matchIfMissing = false)
-  LogLogic logLogic(
-      DataSource dataSource,
-      Caching caching,
-      DbSchedulerCustomizer customizer,
-      DbSchedulerUiProperties properties,
-      @Value("${db-scheduler-ui.log.table-name:scheduled_execution_logs}") String logTableName,
-      @Value("${db-scheduler-ui.log-limit:0}") int logLimit) {
-    return new LogLogic(
-        customizer.dataSource().orElse(dataSource),
-        customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
-        caching,
-        properties.taskData(),
-        logTableName,
-        logLimit);
+  OverviewService overviewLogic(Scheduler scheduler, ObjectProvider<Task<?>> taskDefinitions) {
+    return new OverviewService(scheduler, taskDefinitions.stream().toList());
   }
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(
-      prefix = "db-scheduler-ui",
-      name = "read-only",
-      havingValue = "false",
-      matchIfMissing = true)
+  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "history", havingValue = "true", matchIfMissing = false)
+  LogLogic logLogic(
+    DataSource dataSource,
+    Caching caching,
+    DbSchedulerCustomizer customizer,
+    DbSchedulerUiProperties properties,
+    @Value("${db-scheduler-ui.log.table-name:scheduled_execution_logs}") String logTableName,
+    @Value("${db-scheduler-ui.log-limit:0}") int logLimit
+  ) {
+    return new LogLogic(
+      customizer.dataSource().orElse(dataSource),
+      customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
+      caching,
+      properties.taskData(),
+      logTableName,
+      logLimit
+    );
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "read-only", havingValue = "false", matchIfMissing = true)
   TaskAdminController taskAdminController(TaskLogic taskLogic) {
     return new TaskAdminController(taskLogic);
   }
@@ -125,11 +130,13 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(
-      prefix = "db-scheduler-ui",
-      name = "history",
-      havingValue = "true",
-      matchIfMissing = false)
+  OverviewController overviewController(OverviewService overviewService) {
+    return new OverviewController(overviewService);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "history", havingValue = "true", matchIfMissing = false)
   LogController logController(LogLogic logLogic) {
     return new LogController(logLogic);
   }
@@ -138,38 +145,42 @@ public class UiApiAutoConfiguration {
   @ConditionalOnWebApplication(type = Type.SERVLET)
   @ConditionalOnMissingBean
   SpaFallbackMvc spaFallbackMvc(
-      @Value("${db-scheduler-ui.context-path:}") String contextPath,
-      @Qualifier("indexHtml") String indexHtml) {
+    @Value("${db-scheduler-ui.context-path:}") String contextPath,
+    @Qualifier("indexHtml") String indexHtml
+  ) {
     return new SpaFallbackMvc(normalizePath(contextPath), indexHtml);
   }
 
   @Bean
   @ConditionalOnWebApplication(type = Type.REACTIVE)
   @ConditionalOnMissingBean
-  public RouterFunction<ServerResponse> dbSchedulerRouter(
-      @Qualifier("indexHtml") String indexHtml) {
+  public RouterFunction<ServerResponse> dbSchedulerRouter(@Qualifier("indexHtml") String indexHtml) {
     return RouterFunctions.route(
-        RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
-        request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml));
+      RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
+      request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml)
+    );
   }
 
   @Bean
   @ConditionalOnMissingBean
   ConfigController configController(DbSchedulerUiProperties properties) {
-    return new ConfigController(properties.history(), properties::readOnly);
+    return new ConfigController(properties.history(), properties.overview(), properties::readOnly);
   }
 
   @Bean
   @ConditionalOnMissingBean
   IndexHtmlController indexHtmlController(
-      @Qualifier("indexHtml") String indexHtml, @Qualifier("contextPath") String contextPath) {
+    @Qualifier("indexHtml") String indexHtml,
+    @Qualifier("contextPath") String contextPath
+  ) {
     return new IndexHtmlController(indexHtml, contextPath);
   }
 
   @Bean
   @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "context-path")
   DbSchedulerUiWebConfiguration dbSchedulerUiWebConfiguration(
-      @Value("${db-scheduler-ui.context-path:}") String contextPath) {
+    @Value("${db-scheduler-ui.context-path:}") String contextPath
+  ) {
     return new DbSchedulerUiWebConfiguration(normalizePath(contextPath));
   }
 
@@ -180,19 +191,17 @@ public class UiApiAutoConfiguration {
 
   @Bean(name = "indexHtml")
   public String indexHtml(@Qualifier("contextPath") String contextPath) throws IOException {
-    String indexHtml =
-        new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE)
-            .getContentAsString(StandardCharsets.UTF_8);
+    String indexHtml = new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE).getContentAsString(
+      StandardCharsets.UTF_8
+    );
 
     String contextPathScript = contextPath + "/db-scheduler/js/context-path.js";
 
-    return indexHtml
-        .replaceAll("/db-scheduler", contextPath + "/db-scheduler")
-        .replaceAll(
-            "<head>",
-            """
-                <head>
-                    <script src='%s'></script>"""
-                .formatted(contextPathScript));
+    return indexHtml.replaceAll("/db-scheduler", contextPath + "/db-scheduler").replaceAll(
+      "<head>",
+      """
+      <head>
+          <script src='%s'></script>""".formatted(contextPathScript)
+    );
   }
 }

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -66,10 +66,9 @@ public class UiApiAutoConfiguration {
   private final String dbSchedulerContextPath;
 
   UiApiAutoConfiguration(
-    @Value("${server.servlet.context-path:}") String servletContextPath,
-    @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
-    @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath
-  ) {
+      @Value("${server.servlet.context-path:}") String servletContextPath,
+      @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
+      @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath) {
     logger.info("UiApiAutoConfiguration created");
     this.servletContextPath = normalizePaths(servletContextPath);
     this.dbSchedulerContextPath = normalizePaths(dbSchedulerContextPath);
@@ -90,34 +89,45 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "overview",
+      havingValue = "true",
+      matchIfMissing = false)
   OverviewService overviewLogic(Scheduler scheduler, ObjectProvider<Task<?>> taskDefinitions) {
     return new OverviewService(scheduler, taskDefinitions.stream().toList());
   }
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "history", havingValue = "true", matchIfMissing = false)
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "history",
+      havingValue = "true",
+      matchIfMissing = false)
   LogLogic logLogic(
-    DataSource dataSource,
-    Caching caching,
-    DbSchedulerCustomizer customizer,
-    DbSchedulerUiProperties properties,
-    @Value("${db-scheduler-ui.log.table-name:scheduled_execution_logs}") String logTableName,
-    @Value("${db-scheduler-ui.log-limit:0}") int logLimit
-  ) {
+      DataSource dataSource,
+      Caching caching,
+      DbSchedulerCustomizer customizer,
+      DbSchedulerUiProperties properties,
+      @Value("${db-scheduler-ui.log.table-name:scheduled_execution_logs}") String logTableName,
+      @Value("${db-scheduler-ui.log-limit:0}") int logLimit) {
     return new LogLogic(
-      customizer.dataSource().orElse(dataSource),
-      customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
-      caching,
-      properties.taskData(),
-      logTableName,
-      logLimit
-    );
+        customizer.dataSource().orElse(dataSource),
+        customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
+        caching,
+        properties.taskData(),
+        logTableName,
+        logLimit);
   }
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "read-only", havingValue = "false", matchIfMissing = true)
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "read-only",
+      havingValue = "false",
+      matchIfMissing = true)
   TaskAdminController taskAdminController(TaskLogic taskLogic) {
     return new TaskAdminController(taskLogic);
   }
@@ -130,13 +140,22 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "overview",
+      havingValue = "true",
+      matchIfMissing = false)
   OverviewController overviewController(OverviewService overviewService) {
     return new OverviewController(overviewService);
   }
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "history", havingValue = "true", matchIfMissing = false)
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "history",
+      havingValue = "true",
+      matchIfMissing = false)
   LogController logController(LogLogic logLogic) {
     return new LogController(logLogic);
   }
@@ -145,20 +164,19 @@ public class UiApiAutoConfiguration {
   @ConditionalOnWebApplication(type = Type.SERVLET)
   @ConditionalOnMissingBean
   SpaFallbackMvc spaFallbackMvc(
-    @Value("${db-scheduler-ui.context-path:}") String contextPath,
-    @Qualifier("indexHtml") String indexHtml
-  ) {
+      @Value("${db-scheduler-ui.context-path:}") String contextPath,
+      @Qualifier("indexHtml") String indexHtml) {
     return new SpaFallbackMvc(normalizePath(contextPath), indexHtml);
   }
 
   @Bean
   @ConditionalOnWebApplication(type = Type.REACTIVE)
   @ConditionalOnMissingBean
-  public RouterFunction<ServerResponse> dbSchedulerRouter(@Qualifier("indexHtml") String indexHtml) {
+  public RouterFunction<ServerResponse> dbSchedulerRouter(
+      @Qualifier("indexHtml") String indexHtml) {
     return RouterFunctions.route(
-      RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
-      request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml)
-    );
+        RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
+        request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml));
   }
 
   @Bean
@@ -170,17 +188,14 @@ public class UiApiAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   IndexHtmlController indexHtmlController(
-    @Qualifier("indexHtml") String indexHtml,
-    @Qualifier("contextPath") String contextPath
-  ) {
+      @Qualifier("indexHtml") String indexHtml, @Qualifier("contextPath") String contextPath) {
     return new IndexHtmlController(indexHtml, contextPath);
   }
 
   @Bean
   @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "context-path")
   DbSchedulerUiWebConfiguration dbSchedulerUiWebConfiguration(
-    @Value("${db-scheduler-ui.context-path:}") String contextPath
-  ) {
+      @Value("${db-scheduler-ui.context-path:}") String contextPath) {
     return new DbSchedulerUiWebConfiguration(normalizePath(contextPath));
   }
 
@@ -191,17 +206,19 @@ public class UiApiAutoConfiguration {
 
   @Bean(name = "indexHtml")
   public String indexHtml(@Qualifier("contextPath") String contextPath) throws IOException {
-    String indexHtml = new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE).getContentAsString(
-      StandardCharsets.UTF_8
-    );
+    String indexHtml =
+        new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE)
+            .getContentAsString(StandardCharsets.UTF_8);
 
     String contextPathScript = contextPath + "/db-scheduler/js/context-path.js";
 
-    return indexHtml.replaceAll("/db-scheduler", contextPath + "/db-scheduler").replaceAll(
-      "<head>",
-      """
+    return indexHtml
+        .replaceAll("/db-scheduler", contextPath + "/db-scheduler")
+        .replaceAll(
+            "<head>",
+            """
       <head>
-          <script src='%s'></script>""".formatted(contextPathScript)
-    );
+          <script src='%s'></script>"""
+                .formatted(contextPathScript));
   }
 }

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  * @param readOnly when true, disables mutating endpoints (rerun, delete, reschedule)
  * @param taskData whether to surface serialized task data in API responses
  * @param history whether the UI exposes task execution history (requires the log writer)
+ * @param overview whether the UI exposes the task-centric overview page
  * @param logLimit cap on the number of history rows fetched per request; 0 applies no explicit
  *     {@code LIMIT} clause, but the result set is still capped at 500 rows by the query layer
  */
@@ -32,4 +33,5 @@ public record DbSchedulerUiProperties(
     @DefaultValue("false") boolean readOnly,
     @DefaultValue("true") boolean taskData,
     @DefaultValue("false") boolean history,
+    @DefaultValue("false") boolean overview,
     @DefaultValue("0") int logLimit) {}

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -19,22 +19,26 @@ import static no.bekk.dbscheduler.uistarter.config.DbSchedulerUiUtil.normalizePa
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
+import com.github.kagkarlsson.scheduler.task.Task;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import javax.sql.DataSource;
 import no.bekk.dbscheduler.ui.controller.ConfigController;
 import no.bekk.dbscheduler.ui.controller.IndexHtmlController;
 import no.bekk.dbscheduler.ui.controller.LogController;
+import no.bekk.dbscheduler.ui.controller.OverviewController;
 import no.bekk.dbscheduler.ui.controller.SpaFallbackMvc;
 import no.bekk.dbscheduler.ui.controller.TaskAdminController;
 import no.bekk.dbscheduler.ui.controller.TaskController;
 import no.bekk.dbscheduler.ui.service.LogLogic;
+import no.bekk.dbscheduler.ui.service.OverviewService;
 import no.bekk.dbscheduler.ui.service.TaskLogic;
 import no.bekk.dbscheduler.ui.util.Caching;
 import no.bekk.dbscheduler.uistarter.config.DbSchedulerUiProperties;
 import no.bekk.dbscheduler.uistarter.config.DbSchedulerUiWebConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -62,9 +66,10 @@ public class UiApiAutoConfiguration {
   private final String dbSchedulerContextPath;
 
   UiApiAutoConfiguration(
-      @Value("${server.servlet.context-path:}") String servletContextPath,
-      @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
-      @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath) {
+    @Value("${server.servlet.context-path:}") String servletContextPath,
+    @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
+    @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath
+  ) {
     logger.info("UiApiAutoConfiguration created");
     this.servletContextPath = normalizePaths(servletContextPath);
     this.dbSchedulerContextPath = normalizePaths(dbSchedulerContextPath);
@@ -85,34 +90,34 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(
-      prefix = "db-scheduler-ui",
-      name = "history",
-      havingValue = "true",
-      matchIfMissing = false)
-  LogLogic logLogic(
-      DataSource dataSource,
-      Caching caching,
-      DbSchedulerCustomizer customizer,
-      DbSchedulerUiProperties properties,
-      @Value("${db-scheduler-ui.log.table-name:scheduled_execution_logs}") String logTableName,
-      @Value("${db-scheduler-ui.log-limit:0}") int logLimit) {
-    return new LogLogic(
-        customizer.dataSource().orElse(dataSource),
-        customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
-        caching,
-        properties.taskData(),
-        logTableName,
-        logLimit);
+  OverviewService overviewLogic(Scheduler scheduler, ObjectProvider<Task<?>> taskDefinitions) {
+    return new OverviewService(scheduler, taskDefinitions.stream().toList());
   }
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(
-      prefix = "db-scheduler-ui",
-      name = "read-only",
-      havingValue = "false",
-      matchIfMissing = true)
+  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "history", havingValue = "true", matchIfMissing = false)
+  LogLogic logLogic(
+    DataSource dataSource,
+    Caching caching,
+    DbSchedulerCustomizer customizer,
+    DbSchedulerUiProperties properties,
+    @Value("${db-scheduler-ui.log.table-name:scheduled_execution_logs}") String logTableName,
+    @Value("${db-scheduler-ui.log-limit:0}") int logLimit
+  ) {
+    return new LogLogic(
+      customizer.dataSource().orElse(dataSource),
+      customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
+      caching,
+      properties.taskData(),
+      logTableName,
+      logLimit
+    );
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "read-only", havingValue = "false", matchIfMissing = true)
   TaskAdminController taskAdminController(TaskLogic taskLogic) {
     return new TaskAdminController(taskLogic);
   }
@@ -125,11 +130,13 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(
-      prefix = "db-scheduler-ui",
-      name = "history",
-      havingValue = "true",
-      matchIfMissing = false)
+  OverviewController overviewController(OverviewService overviewService) {
+    return new OverviewController(overviewService);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "history", havingValue = "true", matchIfMissing = false)
   LogController logController(LogLogic logLogic) {
     return new LogController(logLogic);
   }
@@ -138,38 +145,42 @@ public class UiApiAutoConfiguration {
   @ConditionalOnWebApplication(type = Type.SERVLET)
   @ConditionalOnMissingBean
   SpaFallbackMvc spaFallbackMvc(
-      @Value("${db-scheduler-ui.context-path:}") String contextPath,
-      @Qualifier("indexHtml") String indexHtml) {
+    @Value("${db-scheduler-ui.context-path:}") String contextPath,
+    @Qualifier("indexHtml") String indexHtml
+  ) {
     return new SpaFallbackMvc(normalizePath(contextPath), indexHtml);
   }
 
   @Bean
   @ConditionalOnWebApplication(type = Type.REACTIVE)
   @ConditionalOnMissingBean
-  public RouterFunction<ServerResponse> dbSchedulerRouter(
-      @Qualifier("indexHtml") String indexHtml) {
+  public RouterFunction<ServerResponse> dbSchedulerRouter(@Qualifier("indexHtml") String indexHtml) {
     return RouterFunctions.route(
-        RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
-        request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml));
+      RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
+      request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml)
+    );
   }
 
   @Bean
   @ConditionalOnMissingBean
   ConfigController configController(DbSchedulerUiProperties properties) {
-    return new ConfigController(properties.history(), properties::readOnly);
+    return new ConfigController(properties.history(), properties.overview(), properties::readOnly);
   }
 
   @Bean
   @ConditionalOnMissingBean
   IndexHtmlController indexHtmlController(
-      @Qualifier("indexHtml") String indexHtml, @Qualifier("contextPath") String contextPath) {
+    @Qualifier("indexHtml") String indexHtml,
+    @Qualifier("contextPath") String contextPath
+  ) {
     return new IndexHtmlController(indexHtml, contextPath);
   }
 
   @Bean
   @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "context-path")
   DbSchedulerUiWebConfiguration dbSchedulerUiWebConfiguration(
-      @Value("${db-scheduler-ui.context-path:}") String contextPath) {
+    @Value("${db-scheduler-ui.context-path:}") String contextPath
+  ) {
     return new DbSchedulerUiWebConfiguration(normalizePath(contextPath));
   }
 
@@ -180,19 +191,17 @@ public class UiApiAutoConfiguration {
 
   @Bean(name = "indexHtml")
   public String indexHtml(@Qualifier("contextPath") String contextPath) throws IOException {
-    String indexHtml =
-        new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE)
-            .getContentAsString(StandardCharsets.UTF_8);
+    String indexHtml = new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE).getContentAsString(
+      StandardCharsets.UTF_8
+    );
 
     String contextPathScript = contextPath + "/db-scheduler/js/context-path.js";
 
-    return indexHtml
-        .replaceAll("/db-scheduler", contextPath + "/db-scheduler")
-        .replaceAll(
-            "<head>",
-            """
-                <head>
-                    <script src='%s'></script>"""
-                .formatted(contextPathScript));
+    return indexHtml.replaceAll("/db-scheduler", contextPath + "/db-scheduler").replaceAll(
+      "<head>",
+      """
+      <head>
+          <script src='%s'></script>""".formatted(contextPathScript)
+    );
   }
 }

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -66,10 +66,9 @@ public class UiApiAutoConfiguration {
   private final String dbSchedulerContextPath;
 
   UiApiAutoConfiguration(
-    @Value("${server.servlet.context-path:}") String servletContextPath,
-    @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
-    @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath
-  ) {
+      @Value("${server.servlet.context-path:}") String servletContextPath,
+      @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
+      @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath) {
     logger.info("UiApiAutoConfiguration created");
     this.servletContextPath = normalizePaths(servletContextPath);
     this.dbSchedulerContextPath = normalizePaths(dbSchedulerContextPath);
@@ -90,34 +89,45 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "overview",
+      havingValue = "true",
+      matchIfMissing = false)
   OverviewService overviewLogic(Scheduler scheduler, ObjectProvider<Task<?>> taskDefinitions) {
     return new OverviewService(scheduler, taskDefinitions.stream().toList());
   }
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "history", havingValue = "true", matchIfMissing = false)
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "history",
+      havingValue = "true",
+      matchIfMissing = false)
   LogLogic logLogic(
-    DataSource dataSource,
-    Caching caching,
-    DbSchedulerCustomizer customizer,
-    DbSchedulerUiProperties properties,
-    @Value("${db-scheduler-ui.log.table-name:scheduled_execution_logs}") String logTableName,
-    @Value("${db-scheduler-ui.log-limit:0}") int logLimit
-  ) {
+      DataSource dataSource,
+      Caching caching,
+      DbSchedulerCustomizer customizer,
+      DbSchedulerUiProperties properties,
+      @Value("${db-scheduler-ui.log.table-name:scheduled_execution_logs}") String logTableName,
+      @Value("${db-scheduler-ui.log-limit:0}") int logLimit) {
     return new LogLogic(
-      customizer.dataSource().orElse(dataSource),
-      customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
-      caching,
-      properties.taskData(),
-      logTableName,
-      logLimit
-    );
+        customizer.dataSource().orElse(dataSource),
+        customizer.serializer().orElse(Serializer.DEFAULT_JAVA_SERIALIZER),
+        caching,
+        properties.taskData(),
+        logTableName,
+        logLimit);
   }
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "read-only", havingValue = "false", matchIfMissing = true)
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "read-only",
+      havingValue = "false",
+      matchIfMissing = true)
   TaskAdminController taskAdminController(TaskLogic taskLogic) {
     return new TaskAdminController(taskLogic);
   }
@@ -130,13 +140,22 @@ public class UiApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "overview",
+      havingValue = "true",
+      matchIfMissing = false)
   OverviewController overviewController(OverviewService overviewService) {
     return new OverviewController(overviewService);
   }
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "history", havingValue = "true", matchIfMissing = false)
+  @ConditionalOnProperty(
+      prefix = "db-scheduler-ui",
+      name = "history",
+      havingValue = "true",
+      matchIfMissing = false)
   LogController logController(LogLogic logLogic) {
     return new LogController(logLogic);
   }
@@ -145,20 +164,19 @@ public class UiApiAutoConfiguration {
   @ConditionalOnWebApplication(type = Type.SERVLET)
   @ConditionalOnMissingBean
   SpaFallbackMvc spaFallbackMvc(
-    @Value("${db-scheduler-ui.context-path:}") String contextPath,
-    @Qualifier("indexHtml") String indexHtml
-  ) {
+      @Value("${db-scheduler-ui.context-path:}") String contextPath,
+      @Qualifier("indexHtml") String indexHtml) {
     return new SpaFallbackMvc(normalizePath(contextPath), indexHtml);
   }
 
   @Bean
   @ConditionalOnWebApplication(type = Type.REACTIVE)
   @ConditionalOnMissingBean
-  public RouterFunction<ServerResponse> dbSchedulerRouter(@Qualifier("indexHtml") String indexHtml) {
+  public RouterFunction<ServerResponse> dbSchedulerRouter(
+      @Qualifier("indexHtml") String indexHtml) {
     return RouterFunctions.route(
-      RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
-      request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml)
-    );
+        RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
+        request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml));
   }
 
   @Bean
@@ -170,17 +188,14 @@ public class UiApiAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   IndexHtmlController indexHtmlController(
-    @Qualifier("indexHtml") String indexHtml,
-    @Qualifier("contextPath") String contextPath
-  ) {
+      @Qualifier("indexHtml") String indexHtml, @Qualifier("contextPath") String contextPath) {
     return new IndexHtmlController(indexHtml, contextPath);
   }
 
   @Bean
   @ConditionalOnProperty(prefix = "db-scheduler-ui", name = "context-path")
   DbSchedulerUiWebConfiguration dbSchedulerUiWebConfiguration(
-    @Value("${db-scheduler-ui.context-path:}") String contextPath
-  ) {
+      @Value("${db-scheduler-ui.context-path:}") String contextPath) {
     return new DbSchedulerUiWebConfiguration(normalizePath(contextPath));
   }
 
@@ -191,17 +206,19 @@ public class UiApiAutoConfiguration {
 
   @Bean(name = "indexHtml")
   public String indexHtml(@Qualifier("contextPath") String contextPath) throws IOException {
-    String indexHtml = new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE).getContentAsString(
-      StandardCharsets.UTF_8
-    );
+    String indexHtml =
+        new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE)
+            .getContentAsString(StandardCharsets.UTF_8);
 
     String contextPathScript = contextPath + "/db-scheduler/js/context-path.js";
 
-    return indexHtml.replaceAll("/db-scheduler", contextPath + "/db-scheduler").replaceAll(
-      "<head>",
-      """
+    return indexHtml
+        .replaceAll("/db-scheduler", contextPath + "/db-scheduler")
+        .replaceAll(
+            "<head>",
+            """
       <head>
-          <script src='%s'></script>""".formatted(contextPathScript)
-    );
+          <script src='%s'></script>"""
+                .formatted(contextPathScript));
   }
 }

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  * @param readOnly when true, disables mutating endpoints (rerun, delete, reschedule)
  * @param taskData whether to surface serialized task data in API responses
  * @param history whether the UI exposes task execution history (requires the log writer)
+ * @param overview whether the UI exposes the task-centric overview page
  * @param logLimit cap on the number of history rows fetched per request; 0 applies no explicit
  *     {@code LIMIT} clause, but the result set is still capped at 500 rows by the query layer
  */
@@ -32,4 +33,5 @@ public record DbSchedulerUiProperties(
     @DefaultValue("false") boolean readOnly,
     @DefaultValue("true") boolean taskData,
     @DefaultValue("false") boolean history,
+    @DefaultValue("false") boolean overview,
     @DefaultValue("0") int logLimit) {}

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/OverviewController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/OverviewController.java
@@ -13,8 +13,9 @@
  */
 package no.bekk.dbscheduler.ui.controller;
 
-import java.util.function.Supplier;
-import no.bekk.dbscheduler.ui.model.ConfigResponse;
+import java.util.List;
+import no.bekk.dbscheduler.ui.model.OverviewTask;
+import no.bekk.dbscheduler.ui.service.OverviewService;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,21 +23,17 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @CrossOrigin
-@RequestMapping("/db-scheduler-api/config")
-public class ConfigController {
+@RequestMapping("/db-scheduler-api/tasks")
+public class OverviewController {
 
-  private final boolean showHistory;
-  private final boolean showOverview;
-  private final Supplier<Boolean> readOnly;
+  private final OverviewService overviewService;
 
-  public ConfigController(boolean showHistory, boolean showOverview, Supplier<Boolean> readOnly) {
-    this.showHistory = showHistory;
-    this.showOverview = showOverview;
-    this.readOnly = readOnly;
+  public OverviewController(OverviewService overviewService) {
+    this.overviewService = overviewService;
   }
 
-  @GetMapping
-  public ConfigResponse getConfig() {
-    return new ConfigResponse(showHistory, showOverview, readOnly.get());
+  @GetMapping("/overview")
+  public List<OverviewTask> getOverviewTasks() {
+    return overviewService.getOverviewTasks();
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTask.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTask.java
@@ -14,23 +14,14 @@
 package no.bekk.dbscheduler.ui.model;
 
 import java.time.Instant;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-public class OverviewTask {
-  private String taskName;
-  private Boolean recurring;
-  private int instanceCount;
-  private OverviewTaskCounts counts;
-  private OverviewTaskStatus worstStatus;
-  private Instant nextExecutionTime;
-  private Instant lastSuccess;
-  private Instant lastFailure;
-  private int maxConsecutiveFailures;
-}
+public record OverviewTask(
+    String taskName,
+    Boolean recurring,
+    int instanceCount,
+    OverviewTaskCounts counts,
+    OverviewTaskStatus worstStatus,
+    Instant nextExecutionTime,
+    Instant lastSuccess,
+    Instant lastFailure,
+    int maxConsecutiveFailures) {}

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTask.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTask.java
@@ -13,15 +13,24 @@
  */
 package no.bekk.dbscheduler.ui.model;
 
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
-public class ConfigResponse {
-  private boolean showHistory;
-  private boolean showOverview;
-  private boolean readOnly;
+public class OverviewTask {
+  private String taskName;
+  private Boolean recurring;
+  private int instanceCount;
+  private OverviewTaskCounts counts;
+  private OverviewTaskStatus worstStatus;
+  private Instant nextExecutionTime;
+  private Instant lastSuccess;
+  private Instant lastFailure;
+  private int maxConsecutiveFailures;
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTaskCounts.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTaskCounts.java
@@ -13,17 +13,4 @@
  */
 package no.bekk.dbscheduler.ui.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-public class OverviewTaskCounts {
-  private int failing;
-  private int running;
-  private int scheduled;
-}
+public record OverviewTaskCounts(int failing, int running, int scheduled) {}

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTaskCounts.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTaskCounts.java
@@ -15,13 +15,15 @@ package no.bekk.dbscheduler.ui.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
-public class ConfigResponse {
-  private boolean showHistory;
-  private boolean showOverview;
-  private boolean readOnly;
+public class OverviewTaskCounts {
+  private int failing;
+  private int running;
+  private int scheduled;
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTaskStatus.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/OverviewTaskStatus.java
@@ -13,15 +13,9 @@
  */
 package no.bekk.dbscheduler.ui.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
-@AllArgsConstructor
-public class ConfigResponse {
-  private boolean showHistory;
-  private boolean showOverview;
-  private boolean readOnly;
+public enum OverviewTaskStatus {
+  FAILING,
+  RUNNING,
+  SCHEDULED,
+  DORMANT
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/service/OverviewService.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/service/OverviewService.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.bekk.dbscheduler.ui.service;
+
+import com.github.kagkarlsson.scheduler.SchedulerClient;
+import com.github.kagkarlsson.scheduler.TaskSummary;
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTaskWithPersistentSchedule;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import no.bekk.dbscheduler.ui.model.OverviewTask;
+import no.bekk.dbscheduler.ui.model.OverviewTaskCounts;
+import no.bekk.dbscheduler.ui.model.OverviewTaskStatus;
+
+/**
+ * Builds the task-centric overview by delegating aggregation to db-scheduler's {@link
+ * SchedulerClient#getScheduledExecutionsSummaryByTask()}, which performs the grouping and counting
+ * in a single {@code GROUP BY task_name} query. The summary covers every task that currently has
+ * scheduled executions; this class only enriches it with information db-scheduler does not track:
+ * whether a task is recurring, and dormant rows for one-time tasks that have no live execution.
+ */
+public class OverviewService {
+
+  private final SchedulerClient scheduler;
+  private final List<Task<?>> taskDefinitions;
+  private final boolean taskDefinitionsAvailable;
+
+  public OverviewService(SchedulerClient scheduler) {
+    this(scheduler, null);
+  }
+
+  public OverviewService(SchedulerClient scheduler, Collection<Task<?>> taskDefinitions) {
+    this.scheduler = scheduler;
+    this.taskDefinitionsAvailable = taskDefinitions != null && !taskDefinitions.isEmpty();
+    this.taskDefinitions =
+      taskDefinitions == null
+        ? List.of()
+        : taskDefinitions.stream().sorted(Comparator.comparing(Task::getName)).collect(Collectors.toList());
+  }
+
+  public List<OverviewTask> getOverviewTasks() {
+    List<TaskSummary> summaries = scheduler.getScheduledExecutionsSummaryByTask();
+
+    Set<String> recurringTaskNames = taskDefinitions
+      .stream()
+      .filter(this::isRecurringTaskDefinition)
+      .map(Task::getName)
+      .collect(Collectors.toSet());
+    Set<String> summarizedTaskNames = summaries.stream().map(TaskSummary::taskName).collect(Collectors.toSet());
+
+    List<OverviewTask> overviewTasks = new ArrayList<>();
+    summaries.forEach(summary -> overviewTasks.add(toOverviewTask(summary, recurringTaskNames)));
+
+    if (taskDefinitionsAvailable) {
+      taskDefinitions
+        .stream()
+        .filter(task -> !recurringTaskNames.contains(task.getName()))
+        .filter(task -> !summarizedTaskNames.contains(task.getName()))
+        .map(this::dormantTask)
+        .forEach(overviewTasks::add);
+    }
+
+    overviewTasks.sort(Comparator.comparing(OverviewTask::getTaskName));
+    return overviewTasks;
+  }
+
+  private OverviewTask toOverviewTask(TaskSummary summary, Set<String> recurringTaskNames) {
+    OverviewTaskCounts counts = new OverviewTaskCounts(
+      summary.failingCount(),
+      summary.runningCount(),
+      summary.scheduledCount()
+    );
+    return new OverviewTask(
+      summary.taskName(),
+      taskDefinitionsAvailable ? recurringTaskNames.contains(summary.taskName()) : null,
+      summary.instanceCount(),
+      counts,
+      worstStatus(counts),
+      summary.earliestExecutionTime(),
+      summary.latestLastSuccess(),
+      summary.latestLastFailure(),
+      summary.maxConsecutiveFailures()
+    );
+  }
+
+  private OverviewTask dormantTask(Task<?> task) {
+    return new OverviewTask(
+      task.getName(),
+      false,
+      0,
+      new OverviewTaskCounts(0, 0, 0),
+      OverviewTaskStatus.DORMANT,
+      null,
+      null,
+      null,
+      0
+    );
+  }
+
+  private OverviewTaskStatus worstStatus(OverviewTaskCounts counts) {
+    if (counts.getFailing() > 0) {
+      return OverviewTaskStatus.FAILING;
+    }
+    if (counts.getRunning() > 0) {
+      return OverviewTaskStatus.RUNNING;
+    }
+    return OverviewTaskStatus.SCHEDULED;
+  }
+
+  private boolean isRecurringTaskDefinition(Task<?> task) {
+    return task instanceof RecurringTask<?> || task instanceof RecurringTaskWithPersistentSchedule<?>;
+  }
+}

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/service/OverviewService.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/service/OverviewService.java
@@ -49,81 +49,80 @@ public class OverviewService {
     this.scheduler = scheduler;
     this.taskDefinitionsAvailable = taskDefinitions != null && !taskDefinitions.isEmpty();
     this.taskDefinitions =
-      taskDefinitions == null
-        ? List.of()
-        : taskDefinitions.stream().sorted(Comparator.comparing(Task::getName)).collect(Collectors.toList());
+        taskDefinitions == null
+            ? List.of()
+            : taskDefinitions.stream()
+                .sorted(Comparator.comparing(Task::getName))
+                .collect(Collectors.toList());
   }
 
   public List<OverviewTask> getOverviewTasks() {
     List<TaskSummary> summaries = scheduler.getScheduledExecutionsSummaryByTask();
 
-    Set<String> recurringTaskNames = taskDefinitions
-      .stream()
-      .filter(this::isRecurringTaskDefinition)
-      .map(Task::getName)
-      .collect(Collectors.toSet());
-    Set<String> summarizedTaskNames = summaries.stream().map(TaskSummary::taskName).collect(Collectors.toSet());
+    Set<String> recurringTaskNames =
+        taskDefinitions.stream()
+            .filter(this::isRecurringTaskDefinition)
+            .map(Task::getName)
+            .collect(Collectors.toSet());
+    Set<String> summarizedTaskNames =
+        summaries.stream().map(TaskSummary::taskName).collect(Collectors.toSet());
 
     List<OverviewTask> overviewTasks = new ArrayList<>();
     summaries.forEach(summary -> overviewTasks.add(toOverviewTask(summary, recurringTaskNames)));
 
     if (taskDefinitionsAvailable) {
-      taskDefinitions
-        .stream()
-        .filter(task -> !recurringTaskNames.contains(task.getName()))
-        .filter(task -> !summarizedTaskNames.contains(task.getName()))
-        .map(this::dormantTask)
-        .forEach(overviewTasks::add);
+      taskDefinitions.stream()
+          .filter(task -> !recurringTaskNames.contains(task.getName()))
+          .filter(task -> !summarizedTaskNames.contains(task.getName()))
+          .map(this::dormantTask)
+          .forEach(overviewTasks::add);
     }
 
-    overviewTasks.sort(Comparator.comparing(OverviewTask::getTaskName));
+    overviewTasks.sort(Comparator.comparing(OverviewTask::taskName));
     return overviewTasks;
   }
 
   private OverviewTask toOverviewTask(TaskSummary summary, Set<String> recurringTaskNames) {
-    OverviewTaskCounts counts = new OverviewTaskCounts(
-      summary.failingCount(),
-      summary.runningCount(),
-      summary.scheduledCount()
-    );
+    OverviewTaskCounts counts =
+        new OverviewTaskCounts(
+            summary.failingCount(), summary.runningCount(), summary.scheduledCount());
     return new OverviewTask(
-      summary.taskName(),
-      taskDefinitionsAvailable ? recurringTaskNames.contains(summary.taskName()) : null,
-      summary.instanceCount(),
-      counts,
-      worstStatus(counts),
-      summary.earliestExecutionTime(),
-      summary.latestLastSuccess(),
-      summary.latestLastFailure(),
-      summary.maxConsecutiveFailures()
-    );
+        summary.taskName(),
+        taskDefinitionsAvailable ? recurringTaskNames.contains(summary.taskName()) : null,
+        summary.instanceCount(),
+        counts,
+        worstStatus(counts),
+        summary.earliestExecutionTime(),
+        summary.latestLastSuccess(),
+        summary.latestLastFailure(),
+        summary.maxConsecutiveFailures());
   }
 
   private OverviewTask dormantTask(Task<?> task) {
     return new OverviewTask(
-      task.getName(),
-      false,
-      0,
-      new OverviewTaskCounts(0, 0, 0),
-      OverviewTaskStatus.DORMANT,
-      null,
-      null,
-      null,
-      0
-    );
+        task.getName(),
+        false,
+        0,
+        new OverviewTaskCounts(0, 0, 0),
+        OverviewTaskStatus.DORMANT,
+        null,
+        null,
+        null,
+        0);
   }
 
   private OverviewTaskStatus worstStatus(OverviewTaskCounts counts) {
-    if (counts.getFailing() > 0) {
+    if (counts.failing() > 0) {
       return OverviewTaskStatus.FAILING;
     }
-    if (counts.getRunning() > 0) {
+    if (counts.running() > 0) {
       return OverviewTaskStatus.RUNNING;
     }
     return OverviewTaskStatus.SCHEDULED;
   }
 
   private boolean isRecurringTaskDefinition(Task<?> task) {
-    return task instanceof RecurringTask<?> || task instanceof RecurringTaskWithPersistentSchedule<?>;
+    return task instanceof RecurringTask<?>
+        || task instanceof RecurringTaskWithPersistentSchedule<?>;
   }
 }

--- a/db-scheduler-ui/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/db-scheduler-ui/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,6 +4,11 @@
       "name": "db-scheduler-ui.context-path",
       "type": "java.lang.String",
       "description": "Add a prefix for the UI context path."
+    },
+    {
+      "name": "db-scheduler-ui.overview",
+      "type": "java.lang.Boolean",
+      "description": "Expose the task-centric overview page in the UI."
     }
   ]
 }

--- a/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/service/OverviewServiceTest.java
+++ b/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/service/OverviewServiceTest.java
@@ -34,111 +34,109 @@ class OverviewServiceTest {
 
   @Test
   void getOverviewTasks_mapsSummariesAndSortsByTaskName() {
-    StubSchedulerClient scheduler = new StubSchedulerClient(
-      List.of(
-        summary(
-          "email",
-          2,
-          1,
-          1,
-          0,
-          NOW.plus(Duration.ofHours(1)),
-          NOW.minus(Duration.ofHours(2)),
-          NOW.minus(Duration.ofDays(1)),
-          2
-        ),
-        summary("billing", 1, 0, 0, 1, NOW.plus(Duration.ofHours(2)), null, null, 0)
-      )
-    );
+    StubSchedulerClient scheduler =
+        new StubSchedulerClient(
+            List.of(
+                summary(
+                    "email",
+                    2,
+                    1,
+                    1,
+                    0,
+                    NOW.plus(Duration.ofHours(1)),
+                    NOW.minus(Duration.ofHours(2)),
+                    NOW.minus(Duration.ofDays(1)),
+                    2),
+                summary("billing", 1, 0, 0, 1, NOW.plus(Duration.ofHours(2)), null, null, 0)));
 
     List<OverviewTask> tasks = new OverviewService(scheduler, List.of()).getOverviewTasks();
 
-    assertThat(tasks).extracting(OverviewTask::getTaskName).containsExactly("billing", "email");
+    assertThat(tasks).extracting(OverviewTask::taskName).containsExactly("billing", "email");
     assertThat(tasks)
-      .filteredOn(task -> task.getTaskName().equals("email"))
-      .singleElement()
-      .satisfies(task -> {
-        assertThat(task.getWorstStatus()).isEqualTo(OverviewTaskStatus.FAILING);
-        assertThat(task.getInstanceCount()).isEqualTo(2);
-        assertThat(task.getCounts().getFailing()).isEqualTo(1);
-        assertThat(task.getCounts().getRunning()).isEqualTo(1);
-        assertThat(task.getCounts().getScheduled()).isZero();
-        assertThat(task.getNextExecutionTime()).isEqualTo(NOW.plus(Duration.ofHours(1)));
-        assertThat(task.getLastSuccess()).isEqualTo(NOW.minus(Duration.ofHours(2)));
-        assertThat(task.getLastFailure()).isEqualTo(NOW.minus(Duration.ofDays(1)));
-        assertThat(task.getMaxConsecutiveFailures()).isEqualTo(2);
-      });
+        .filteredOn(task -> task.taskName().equals("email"))
+        .singleElement()
+        .satisfies(
+            task -> {
+              assertThat(task.worstStatus()).isEqualTo(OverviewTaskStatus.FAILING);
+              assertThat(task.instanceCount()).isEqualTo(2);
+              assertThat(task.counts().failing()).isEqualTo(1);
+              assertThat(task.counts().running()).isEqualTo(1);
+              assertThat(task.counts().scheduled()).isZero();
+              assertThat(task.nextExecutionTime()).isEqualTo(NOW.plus(Duration.ofHours(1)));
+              assertThat(task.lastSuccess()).isEqualTo(NOW.minus(Duration.ofHours(2)));
+              assertThat(task.lastFailure()).isEqualTo(NOW.minus(Duration.ofDays(1)));
+              assertThat(task.maxConsecutiveFailures()).isEqualTo(2);
+            });
   }
 
   @Test
   void getOverviewTasks_marksRecurringFromTaskDefinitions() {
-    StubSchedulerClient scheduler = new StubSchedulerClient(
-      List.of(summary("heartbeat", 1, 0, 0, 1, NOW, null, null, 0))
-    );
+    StubSchedulerClient scheduler =
+        new StubSchedulerClient(List.of(summary("heartbeat", 1, 0, 0, 1, NOW, null, null, 0)));
 
-    List<OverviewTask> tasks = new OverviewService(scheduler, List.of(recurringTask("heartbeat"))).getOverviewTasks();
+    List<OverviewTask> tasks =
+        new OverviewService(scheduler, List.of(recurringTask("heartbeat"))).getOverviewTasks();
 
     assertThat(tasks)
-      .singleElement()
-      .satisfies(task -> {
-        assertThat(task.getTaskName()).isEqualTo("heartbeat");
-        assertThat(task.getRecurring()).isTrue();
-        assertThat(task.getWorstStatus()).isEqualTo(OverviewTaskStatus.SCHEDULED);
-      });
+        .singleElement()
+        .satisfies(
+            task -> {
+              assertThat(task.taskName()).isEqualTo("heartbeat");
+              assertThat(task.recurring()).isTrue();
+              assertThat(task.worstStatus()).isEqualTo(OverviewTaskStatus.SCHEDULED);
+            });
   }
 
   @Test
   void getOverviewTasks_addsDormantRowsForUnscheduledOneTimeDefinitionsOnly() {
     StubSchedulerClient scheduler = new StubSchedulerClient(List.of());
 
-    List<OverviewTask> tasks = new OverviewService(
-      scheduler,
-      List.of(oneTimeTask("manual"), recurringTask("heartbeat"))
-    ).getOverviewTasks();
+    List<OverviewTask> tasks =
+        new OverviewService(scheduler, List.of(oneTimeTask("manual"), recurringTask("heartbeat")))
+            .getOverviewTasks();
 
     assertThat(tasks)
-      .singleElement()
-      .satisfies(task -> {
-        assertThat(task.getTaskName()).isEqualTo("manual");
-        assertThat(task.getRecurring()).isFalse();
-        assertThat(task.getInstanceCount()).isZero();
-        assertThat(task.getWorstStatus()).isEqualTo(OverviewTaskStatus.DORMANT);
-      });
+        .singleElement()
+        .satisfies(
+            task -> {
+              assertThat(task.taskName()).isEqualTo("manual");
+              assertThat(task.recurring()).isFalse();
+              assertThat(task.instanceCount()).isZero();
+              assertThat(task.worstStatus()).isEqualTo(OverviewTaskStatus.DORMANT);
+            });
   }
 
   @Test
   void getOverviewTasks_omitsDormantRowsForRecurringTasksWithPersistentSchedule() {
     StubSchedulerClient scheduler = new StubSchedulerClient(List.of());
 
-    List<OverviewTask> tasks = new OverviewService(
-      scheduler,
-      List.of(recurringWithPersistentScheduleTask("dynamic"))
-    ).getOverviewTasks();
+    List<OverviewTask> tasks =
+        new OverviewService(scheduler, List.of(recurringWithPersistentScheduleTask("dynamic")))
+            .getOverviewTasks();
 
     assertThat(tasks).isEmpty();
   }
 
   @Test
   void getOverviewTasks_degradesWhenTaskDefinitionsAreUnavailable() {
-    StubSchedulerClient scheduler = new StubSchedulerClient(
-      List.of(summary("unknown", 1, 0, 0, 1, NOW, null, null, 0))
-    );
+    StubSchedulerClient scheduler =
+        new StubSchedulerClient(List.of(summary("unknown", 1, 0, 0, 1, NOW, null, null, 0)));
 
     List<OverviewTask> tasks = new OverviewService(scheduler).getOverviewTasks();
 
     assertThat(tasks)
-      .singleElement()
-      .satisfies(task -> {
-        assertThat(task.getTaskName()).isEqualTo("unknown");
-        assertThat(task.getRecurring()).isNull();
-        assertThat(task.getWorstStatus()).isEqualTo(OverviewTaskStatus.SCHEDULED);
-      });
+        .singleElement()
+        .satisfies(
+            task -> {
+              assertThat(task.taskName()).isEqualTo("unknown");
+              assertThat(task.recurring()).isNull();
+              assertThat(task.worstStatus()).isEqualTo(OverviewTaskStatus.SCHEDULED);
+            });
   }
 
   private static Task<Void> recurringTask(String name) {
-    return Tasks.recurring(name, Schedules.fixedDelay(Duration.ofHours(1))).execute(
-      (taskInstance, executionContext) -> {}
-    );
+    return Tasks.recurring(name, Schedules.fixedDelay(Duration.ofHours(1)))
+        .execute((taskInstance, executionContext) -> {});
   }
 
   private static Task<Void> oneTimeTask(String name) {
@@ -146,32 +144,29 @@ class OverviewServiceTest {
   }
 
   private static Task<ScheduleAndData> recurringWithPersistentScheduleTask(String name) {
-    return Tasks.recurringWithPersistentSchedule(name, ScheduleAndData.class).execute(
-      (taskInstance, executionContext) -> {}
-    );
+    return Tasks.recurringWithPersistentSchedule(name, ScheduleAndData.class)
+        .execute((taskInstance, executionContext) -> {});
   }
 
   private static TaskSummary summary(
-    String taskName,
-    int instanceCount,
-    int runningCount,
-    int failingCount,
-    int scheduledCount,
-    Instant earliestExecutionTime,
-    Instant latestLastSuccess,
-    Instant latestLastFailure,
-    int maxConsecutiveFailures
-  ) {
+      String taskName,
+      int instanceCount,
+      int runningCount,
+      int failingCount,
+      int scheduledCount,
+      Instant earliestExecutionTime,
+      Instant latestLastSuccess,
+      Instant latestLastFailure,
+      int maxConsecutiveFailures) {
     return new TaskSummary(
-      taskName,
-      instanceCount,
-      runningCount,
-      failingCount,
-      scheduledCount,
-      earliestExecutionTime,
-      latestLastSuccess,
-      latestLastFailure,
-      maxConsecutiveFailures
-    );
+        taskName,
+        instanceCount,
+        runningCount,
+        failingCount,
+        scheduledCount,
+        earliestExecutionTime,
+        latestLastSuccess,
+        latestLastFailure,
+        maxConsecutiveFailures);
   }
 }

--- a/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/service/OverviewServiceTest.java
+++ b/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/service/OverviewServiceTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.bekk.dbscheduler.ui.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.kagkarlsson.scheduler.TaskSummary;
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.helper.ScheduleAndData;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import no.bekk.dbscheduler.ui.model.OverviewTask;
+import no.bekk.dbscheduler.ui.model.OverviewTaskStatus;
+import no.bekk.dbscheduler.ui.testsupport.StubSchedulerClient;
+import org.junit.jupiter.api.Test;
+
+class OverviewServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-06-05T10:00:00Z");
+
+  @Test
+  void getOverviewTasks_mapsSummariesAndSortsByTaskName() {
+    StubSchedulerClient scheduler = new StubSchedulerClient(
+      List.of(
+        summary(
+          "email",
+          2,
+          1,
+          1,
+          0,
+          NOW.plus(Duration.ofHours(1)),
+          NOW.minus(Duration.ofHours(2)),
+          NOW.minus(Duration.ofDays(1)),
+          2
+        ),
+        summary("billing", 1, 0, 0, 1, NOW.plus(Duration.ofHours(2)), null, null, 0)
+      )
+    );
+
+    List<OverviewTask> tasks = new OverviewService(scheduler, List.of()).getOverviewTasks();
+
+    assertThat(tasks).extracting(OverviewTask::getTaskName).containsExactly("billing", "email");
+    assertThat(tasks)
+      .filteredOn(task -> task.getTaskName().equals("email"))
+      .singleElement()
+      .satisfies(task -> {
+        assertThat(task.getWorstStatus()).isEqualTo(OverviewTaskStatus.FAILING);
+        assertThat(task.getInstanceCount()).isEqualTo(2);
+        assertThat(task.getCounts().getFailing()).isEqualTo(1);
+        assertThat(task.getCounts().getRunning()).isEqualTo(1);
+        assertThat(task.getCounts().getScheduled()).isZero();
+        assertThat(task.getNextExecutionTime()).isEqualTo(NOW.plus(Duration.ofHours(1)));
+        assertThat(task.getLastSuccess()).isEqualTo(NOW.minus(Duration.ofHours(2)));
+        assertThat(task.getLastFailure()).isEqualTo(NOW.minus(Duration.ofDays(1)));
+        assertThat(task.getMaxConsecutiveFailures()).isEqualTo(2);
+      });
+  }
+
+  @Test
+  void getOverviewTasks_marksRecurringFromTaskDefinitions() {
+    StubSchedulerClient scheduler = new StubSchedulerClient(
+      List.of(summary("heartbeat", 1, 0, 0, 1, NOW, null, null, 0))
+    );
+
+    List<OverviewTask> tasks = new OverviewService(scheduler, List.of(recurringTask("heartbeat"))).getOverviewTasks();
+
+    assertThat(tasks)
+      .singleElement()
+      .satisfies(task -> {
+        assertThat(task.getTaskName()).isEqualTo("heartbeat");
+        assertThat(task.getRecurring()).isTrue();
+        assertThat(task.getWorstStatus()).isEqualTo(OverviewTaskStatus.SCHEDULED);
+      });
+  }
+
+  @Test
+  void getOverviewTasks_addsDormantRowsForUnscheduledOneTimeDefinitionsOnly() {
+    StubSchedulerClient scheduler = new StubSchedulerClient(List.of());
+
+    List<OverviewTask> tasks = new OverviewService(
+      scheduler,
+      List.of(oneTimeTask("manual"), recurringTask("heartbeat"))
+    ).getOverviewTasks();
+
+    assertThat(tasks)
+      .singleElement()
+      .satisfies(task -> {
+        assertThat(task.getTaskName()).isEqualTo("manual");
+        assertThat(task.getRecurring()).isFalse();
+        assertThat(task.getInstanceCount()).isZero();
+        assertThat(task.getWorstStatus()).isEqualTo(OverviewTaskStatus.DORMANT);
+      });
+  }
+
+  @Test
+  void getOverviewTasks_omitsDormantRowsForRecurringTasksWithPersistentSchedule() {
+    StubSchedulerClient scheduler = new StubSchedulerClient(List.of());
+
+    List<OverviewTask> tasks = new OverviewService(
+      scheduler,
+      List.of(recurringWithPersistentScheduleTask("dynamic"))
+    ).getOverviewTasks();
+
+    assertThat(tasks).isEmpty();
+  }
+
+  @Test
+  void getOverviewTasks_degradesWhenTaskDefinitionsAreUnavailable() {
+    StubSchedulerClient scheduler = new StubSchedulerClient(
+      List.of(summary("unknown", 1, 0, 0, 1, NOW, null, null, 0))
+    );
+
+    List<OverviewTask> tasks = new OverviewService(scheduler).getOverviewTasks();
+
+    assertThat(tasks)
+      .singleElement()
+      .satisfies(task -> {
+        assertThat(task.getTaskName()).isEqualTo("unknown");
+        assertThat(task.getRecurring()).isNull();
+        assertThat(task.getWorstStatus()).isEqualTo(OverviewTaskStatus.SCHEDULED);
+      });
+  }
+
+  private static Task<Void> recurringTask(String name) {
+    return Tasks.recurring(name, Schedules.fixedDelay(Duration.ofHours(1))).execute(
+      (taskInstance, executionContext) -> {}
+    );
+  }
+
+  private static Task<Void> oneTimeTask(String name) {
+    return Tasks.oneTime(name).execute((taskInstance, executionContext) -> {});
+  }
+
+  private static Task<ScheduleAndData> recurringWithPersistentScheduleTask(String name) {
+    return Tasks.recurringWithPersistentSchedule(name, ScheduleAndData.class).execute(
+      (taskInstance, executionContext) -> {}
+    );
+  }
+
+  private static TaskSummary summary(
+    String taskName,
+    int instanceCount,
+    int runningCount,
+    int failingCount,
+    int scheduledCount,
+    Instant earliestExecutionTime,
+    Instant latestLastSuccess,
+    Instant latestLastFailure,
+    int maxConsecutiveFailures
+  ) {
+    return new TaskSummary(
+      taskName,
+      instanceCount,
+      runningCount,
+      failingCount,
+      scheduledCount,
+      earliestExecutionTime,
+      latestLastSuccess,
+      latestLastFailure,
+      maxConsecutiveFailures
+    );
+  }
+}

--- a/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/testsupport/StubSchedulerClient.java
+++ b/db-scheduler-ui/src/test/java/no/bekk/dbscheduler/ui/testsupport/StubSchedulerClient.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.bekk.dbscheduler.ui.testsupport;
+
+import com.github.kagkarlsson.scheduler.ScheduledExecution;
+import com.github.kagkarlsson.scheduler.ScheduledExecutionsFilter;
+import com.github.kagkarlsson.scheduler.SchedulerClient;
+import com.github.kagkarlsson.scheduler.TaskSummary;
+import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Minimal {@link SchedulerClient} test double that only answers {@link
+ * #getScheduledExecutionsSummaryByTask()} — the single method {@code OverviewLogic} depends on. All
+ * other operations throw, so a test that accidentally relies on them fails loudly rather than
+ * silently observing no-op behaviour.
+ */
+public final class StubSchedulerClient implements SchedulerClient {
+
+  private final List<TaskSummary> summaries;
+
+  public StubSchedulerClient(List<TaskSummary> summaries) {
+    this.summaries = summaries;
+  }
+
+  @Override
+  public List<TaskSummary> getScheduledExecutionsSummaryByTask() {
+    return summaries;
+  }
+
+  @Override
+  public <T> boolean schedule(TaskInstance<T> taskInstance, Instant time, ScheduleOptions options) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> boolean schedule(SchedulableInstance<T> instance, ScheduleOptions options) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> void schedule(TaskInstance<T> taskInstance, Instant time) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> void schedule(SchedulableInstance<T> instance) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> boolean scheduleIfNotExists(TaskInstance<T> taskInstance, Instant time) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> boolean scheduleIfNotExists(SchedulableInstance<T> instance) {
+    throw unsupported();
+  }
+
+  @Override
+  public void scheduleBatch(List<TaskInstance<?>> taskInstances, Instant time) {
+    throw unsupported();
+  }
+
+  @Override
+  public void scheduleBatch(List<SchedulableInstance<?>> instances) {
+    throw unsupported();
+  }
+
+  @Override
+  public boolean reschedule(TaskInstanceId taskInstanceId, Instant newExecutionTime) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> boolean reschedule(
+      TaskInstanceId taskInstanceId, Instant newExecutionTime, T newData) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> boolean reschedule(SchedulableInstance<T> instance) {
+    throw unsupported();
+  }
+
+  @Override
+  public void cancel(TaskInstanceId taskInstanceId) {
+    throw unsupported();
+  }
+
+  @Override
+  public void fetchScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
+    throw unsupported();
+  }
+
+  @Override
+  public void fetchScheduledExecutions(
+      ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> void fetchScheduledExecutionsForTask(
+      String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
+    throw unsupported();
+  }
+
+  @Override
+  public <T> void fetchScheduledExecutionsForTask(
+      String taskName,
+      Class<T> dataClass,
+      ScheduledExecutionsFilter filter,
+      Consumer<ScheduledExecution<T>> consumer) {
+    throw unsupported();
+  }
+
+  @Override
+  public Optional<ScheduledExecution<Object>> getScheduledExecution(TaskInstanceId taskInstanceId) {
+    throw unsupported();
+  }
+
+  private static UnsupportedOperationException unsupported() {
+    return new UnsupportedOperationException("Not supported by StubSchedulerClient");
+  }
+}

--- a/example-app-boot4/src/main/resources/application.properties
+++ b/example-app-boot4/src/main/resources/application.properties
@@ -4,4 +4,5 @@ spring.datasource.driver-class-name=org.h2.Driver
 db-scheduler-ui.log.enabled=true
 db-scheduler-ui.log.table-name=scheduled_execution_logs
 db-scheduler-ui.history=true
+ db-scheduler-ui.overview=true
 db-scheduler-ui.task-data=true

--- a/example-app-webflux/src/main/resources/application.properties
+++ b/example-app-webflux/src/main/resources/application.properties
@@ -4,5 +4,6 @@ spring.datasource.driver-class-name=org.h2.Driver
 db-scheduler-ui.log.enabled=true
 db-scheduler-ui.log.table-name=scheduled_execution_logs
 db-scheduler-ui.history=true
+db-scheduler-ui.overview=true
 db-scheduler-ui.task-data=true
 #logging.level.org.springframework=DEBUG

--- a/example-app/src/main/resources/application.properties
+++ b/example-app/src/main/resources/application.properties
@@ -4,4 +4,5 @@ spring.datasource.driver-class-name=org.h2.Driver
 db-scheduler-ui.log.enabled=true
 db-scheduler-ui.log.table-name=scheduled_execution_logs
 db-scheduler-ui.history=true
+db-scheduler-ui.overview=true
 db-scheduler-ui.task-data=true

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeSpringSecurityTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeSpringSecurityTest.java
@@ -105,7 +105,8 @@ class SmokeSpringSecurityTest {
 
     @Bean
     ConfigController configController(DbSchedulerUiProperties properties) {
-      return new ConfigController(properties.history(), readOnly(properties));
+      return new ConfigController(
+          properties.history(), properties.overview(), readOnly(properties));
     }
 
     private Supplier<Boolean> readOnly(DbSchedulerUiProperties properties) {

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
@@ -76,7 +76,7 @@ class SmokeTest {
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(result.getBody()).isNotNull();
     assertThat(result.getBody())
-        .anyMatch(task -> task.getTaskName().equals(ONE_TIME_TASK.getTaskName()));
+        .anyMatch(task -> task.taskName().equals(ONE_TIME_TASK.getTaskName()));
   }
 
   @Test

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
@@ -4,6 +4,7 @@ import static com.github.bekk.exampleapp.tasks.OneTimeTaskExample.ONE_TIME_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import no.bekk.dbscheduler.ui.model.GetTasksResponse;
+import no.bekk.dbscheduler.ui.model.OverviewTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +65,18 @@ class SmokeTest {
     result.getBody().getItems().forEach(t -> System.out.println(t.getTaskName()));
     assertThat(result.getBody().getItems())
         .anyMatch(taskModel -> taskModel.getTaskName().equals(ONE_TIME_TASK.getTaskName()));
+  }
+
+  @Test
+  void testGetOverviewReturnsExampleOneTimeTask() {
+    ResponseEntity<OverviewTask[]> result =
+        this.restTemplate.getForEntity(
+            baseUrl + "/db-scheduler-api/tasks/overview", OverviewTask[].class);
+
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).isNotNull();
+    assertThat(result.getBody())
+        .anyMatch(task -> task.getTaskName().equals(ONE_TIME_TASK.getTaskName()));
   }
 
   @Test

--- a/example-app/src/test/resources/application.properties
+++ b/example-app/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 spring.datasource.url=jdbc:h2:mem:testdb
+db-scheduler-ui.overview=true

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
         <maven.compiler.release>17</maven.compiler.release>
         <spring-boot.version>3.4.7</spring-boot.version>
         <lombok.version>1.18.38</lombok.version>
-        <db-scheduler.version>15.6.0</db-scheduler.version>
+        <db-scheduler.version>16.12.0</db-scheduler.version>
         <spring-boot-4.version>4.0.2</spring-boot-4.version>
-        <db-scheduler-boot4.version>16.7.0</db-scheduler-boot4.version>
+        <db-scheduler-boot4.version>16.12.0</db-scheduler-boot4.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
- Add task overview page behind feature toggle
- One row per task showing worst status, next/last run times, and recurring vs one-time classification
- New endpoint GET /db-scheduler-api/tasks/overview
- Requires db-scheduler ≥ 16.12.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a task Overview page with status, execution counts, next/last run times, recurrence info, and row navigation.
  * UI navigation updated to surface the Overview page and conditionally route to it.

* **Configuration**
  * New toggle to enable/disable the Overview feature (configurable).

* **Chores**
  * Raised minimum supported db-scheduler version to 16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->