### PR TITLE
fix: render deep-link routes broken after recent merges

### DIFF
--- a/db-scheduler-ui-frontend/src/components/input/DateTimeInput.tsx
+++ b/db-scheduler-ui-frontend/src/components/input/DateTimeInput.tsx
@@ -15,13 +15,11 @@ import DatePickerImport from 'react-datepicker';
 import { Box } from '@chakra-ui/react';
 import 'react-datepicker/dist/react-datepicker.css';
 import colors from 'src/styles/colors';
+import { interopDefault } from 'src/utils/interopDefault';
 
 // react-datepicker v4 is CommonJS; under Vite 8's interop the default import resolves to the
-// module namespace, leaving the component on `.default`. Fall back to the import itself in case
-// a future bundler hands back the component directly.
-const DatePicker =
-  (DatePickerImport as { default?: typeof DatePickerImport }).default ??
-  DatePickerImport;
+// module namespace rather than the component. See interopDefault.
+const DatePicker = interopDefault(DatePickerImport);
 
 interface DateTimeInputProps {
   selectedDate: Date | null;

--- a/db-scheduler-ui-frontend/src/components/input/DateTimeInput.tsx
+++ b/db-scheduler-ui-frontend/src/components/input/DateTimeInput.tsx
@@ -11,10 +11,17 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import DatePicker from 'react-datepicker';
+import DatePickerImport from 'react-datepicker';
 import { Box } from '@chakra-ui/react';
 import 'react-datepicker/dist/react-datepicker.css';
 import colors from 'src/styles/colors';
+
+// react-datepicker v4 is CommonJS; under Vite 8's interop the default import resolves to the
+// module namespace, leaving the component on `.default`. Fall back to the import itself in case
+// a future bundler hands back the component directly.
+const DatePicker =
+  (DatePickerImport as { default?: typeof DatePickerImport }).default ??
+  DatePickerImport;
 
 interface DateTimeInputProps {
   selectedDate: Date | null;

--- a/db-scheduler-ui-frontend/src/utils/interopDefault.ts
+++ b/db-scheduler-ui-frontend/src/utils/interopDefault.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Normalizes the default export of a CommonJS dependency.
+ *
+ * Some CJS packages expose their value on `module.exports.default`. Depending on the bundler's
+ * interop behaviour, the default import can resolve to the module namespace rather than that inner
+ * value (e.g. react-datepicker v4 under Vite 8). This returns the inner `default` when present and
+ * falls back to the import itself when a bundler already hands back the value directly.
+ */
+export const interopDefault = <T>(mod: T): T => (mod as { default?: T }).default ?? mod;

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/SpaFallbackMvc.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/SpaFallbackMvc.java
@@ -69,6 +69,11 @@ public class SpaFallbackMvc implements WebMvcConfigurer {
         public long lastModified() {
           return -1;
         }
+
+        @Override
+        public String getFilename() {
+          return "index.html";
+        }
       };
     }
   }

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(
@@ -101,6 +102,8 @@ class SmokeTest {
         this.restTemplate.getForEntity(baseUrl + "/db-scheduler/some-spa-route", String.class);
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(result.getBody()).contains("/db-scheduler");
+    assertThat(result.getHeaders().getContentType()).isNotNull();
+    assertThat(result.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_HTML)).isTrue();
   }
 
   @BeforeEach


### PR DESCRIPTION
Refreshing the browser on a deep-link route was broken in two independent ways after recent merges. Loading /db-scheduler/overview triggered a file download instead of the app, and /db-scheduler/history/all rendered a blank page.

- The SPA fallback served its index.html shell as a ByteArrayResource with no filename, so Spring defaulted the response to application/octet-stream and browsers downloaded it; the fallback now resolves to text/html (with a SmokeTest assertion guarding it).
- react-datepicker (CommonJS) regressed under the Vite 8 upgrade, where the default import resolved to the module namespace rather than the component, crashing the only view that uses it; the import is now normalized regardless of interop behaviour.

---
This PR was prepared with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module compatibility and SPA fallback handling for better application reliability.
  * Enhanced response header validation for the web interface.

* **Tests**
  * Added validation for response content-type headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->