### PR TITLE
Support configurable UI and API paths

### DIFF
--- a/db-scheduler-ui-frontend/main.tsx
+++ b/db-scheduler-ui-frontend/main.tsx
@@ -14,8 +14,9 @@
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './src/App';
+import { getUiBasePath } from './src/utils/runtimeConfig';
 
-const basename = (window.CONTEXT_PATH || '') + import.meta.env.BASE_URL;
+const basename = getUiBasePath();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <BrowserRouter basename={basename}>

--- a/db-scheduler-ui-frontend/src/services/deleteTask.ts
+++ b/db-scheduler-ui-frontend/src/services/deleteTask.ts
@@ -11,20 +11,22 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
+
+const API_BASE_URL = getApiBaseUrl();
 
 const deleteTask = async (id: string, name: string) => {
+  const queryParams = new URLSearchParams({ id, name });
+
   const response = await fetch(
-    `${API_BASE_URL}/tasks/delete?id=${id}&name=${name}`,
+    `${API_BASE_URL}/tasks/delete?${queryParams}`,
     {
       method: 'POST',
     },
   );
 
   if (response.status == 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(`Error executing task. Status: ${response.statusText}`);
   }

--- a/db-scheduler-ui-frontend/src/services/getLogs.ts
+++ b/db-scheduler-ui-frontend/src/services/getLogs.ts
@@ -14,10 +14,9 @@
 
 import { TaskDetailsRequestParams } from 'src/models/TaskRequestParams';
 import { LogResponse } from 'src/models/TasksResponse';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
 
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+const API_BASE_URL = getApiBaseUrl();
 
 export const ALL_LOG_QUERY_KEY = `logs/all`;
 
@@ -63,7 +62,7 @@ export const getLogs = async (
   });
 
   if (response.status == 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(`Error fetching logs. Status: ${response.statusText}`);
   }

--- a/db-scheduler-ui-frontend/src/services/getOverviewTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/getOverviewTasks.ts
@@ -12,10 +12,9 @@
  * limitations under the License.
  */
 import { OverviewTask } from 'src/models/OverviewTask';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
 
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+const API_BASE_URL = getApiBaseUrl();
 
 export const OVERVIEW_TASKS_QUERY_KEY = 'overviewTasks';
 
@@ -28,7 +27,7 @@ export const getOverviewTasks = async (): Promise<OverviewTask[]> => {
   });
 
   if (response.status === 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(
       `Error fetching overview tasks. Status: ${response.statusText}`,

--- a/db-scheduler-ui-frontend/src/services/getTask.ts
+++ b/db-scheduler-ui-frontend/src/services/getTask.ts
@@ -13,10 +13,9 @@
  */
 import { TasksResponse } from 'src/models/TasksResponse';
 import { TaskDetailsRequestParams } from 'src/models/TaskRequestParams';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
 
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+const API_BASE_URL = getApiBaseUrl();
 
 export const TASK_DETAILS_QUERY_KEY = `tasks/details`;
 
@@ -61,7 +60,7 @@ export const getTask = async (
   });
 
   if (response.status == 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(`Error fetching tasks. Status: ${response.statusText}`);
   }

--- a/db-scheduler-ui-frontend/src/services/getTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/getTasks.ts
@@ -13,10 +13,9 @@
  */
 import { TasksResponse } from 'src/models/TasksResponse';
 import { TaskRequestParams } from 'src/models/TaskRequestParams';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
 
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+const API_BASE_URL = getApiBaseUrl();
 
 export const TASK_QUERY_KEY = `tasks`;
 
@@ -59,7 +58,7 @@ export const getTasks = async (
   });
 
   if (response.status == 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(`Error fetching tasks. Status: ${response.statusText}`);
   }

--- a/db-scheduler-ui-frontend/src/services/pollLogs.ts
+++ b/db-scheduler-ui-frontend/src/services/pollLogs.ts
@@ -13,10 +13,9 @@
  */
 import { PollResponse } from 'src/models/PollResponse';
 import { TaskDetailsRequestParams } from 'src/models/TaskRequestParams';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
 
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+const API_BASE_URL = getApiBaseUrl();
 
 export const POLL_LOGS_QUERY_KEY = `logs/poll`;
 
@@ -61,7 +60,7 @@ export const pollLogs = async (
   });
 
   if (response.status == 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(`Error polling tasks. Status: ${response.statusText}`);
   }

--- a/db-scheduler-ui-frontend/src/services/pollTasks.ts
+++ b/db-scheduler-ui-frontend/src/services/pollTasks.ts
@@ -13,10 +13,9 @@
  */
 import { PollResponse } from 'src/models/PollResponse';
 import { TaskDetailsRequestParams } from 'src/models/TaskRequestParams';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
 
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+const API_BASE_URL = getApiBaseUrl();
 
 export const POLL_TASKS_QUERY_KEY = `tasks/poll`;
 
@@ -61,7 +60,7 @@ export const pollTasks = async (
     },
   });
   if (response.status == 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(`Error polling tasks. Status: ${response.statusText}`);
   }

--- a/db-scheduler-ui-frontend/src/services/runTask.ts
+++ b/db-scheduler-ui-frontend/src/services/runTask.ts
@@ -11,20 +11,19 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
 
-const runTask = async (id: string, name: string, scheduleTime?:Date) => {
+const API_BASE_URL = getApiBaseUrl();
 
+const runTask = async (id: string, name: string, scheduleTime?: Date) => {
   const queryParams = new URLSearchParams();
 
   queryParams.append('id', id);
   queryParams.append('name', name);
   if (scheduleTime) {
-      queryParams.append('scheduleTime', scheduleTime.toISOString());
+    queryParams.append('scheduleTime', scheduleTime.toISOString());
   } else {
-      queryParams.append('scheduleTime', new Date().toISOString());
+    queryParams.append('scheduleTime', new Date().toISOString());
   }
 
   const response = await fetch(
@@ -35,7 +34,7 @@ const runTask = async (id: string, name: string, scheduleTime?:Date) => {
   );
 
   if (response.status == 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(`Error executing task. Status: ${response.statusText}`);
   }

--- a/db-scheduler-ui-frontend/src/services/runTaskGroup.ts
+++ b/db-scheduler-ui-frontend/src/services/runTaskGroup.ts
@@ -11,20 +11,25 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const API_BASE_URL: string =
-  (import.meta.env.VITE_API_BASE_URL as string) ??
-  window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+import { getApiBaseUrl, redirectToUi } from 'src/utils/runtimeConfig';
+
+const API_BASE_URL = getApiBaseUrl();
 
 const runTaskGroup = async (name: string, onlyFailed: boolean) => {
+  const queryParams = new URLSearchParams({
+    name,
+    onlyFailed: String(onlyFailed),
+  });
+
   const response = await fetch(
-    `${API_BASE_URL}/tasks/rerunGroup?name=${name}&onlyFailed=${onlyFailed}`,
+    `${API_BASE_URL}/tasks/rerunGroup?${queryParams}`,
     {
       method: 'POST',
     },
   );
 
   if (response.status == 401) {
-    document.location.href = '/db-scheduler';
+    redirectToUi();
   } else if (!response.ok) {
     throw new Error(`Error executing task. Status: ${response.statusText}`);
   }

--- a/db-scheduler-ui-frontend/src/utils/config.ts
+++ b/db-scheduler-ui-frontend/src/utils/config.ts
@@ -12,11 +12,9 @@
  * limitations under the License.
  */
 
-const API_BASE_URL: string =
-    (import.meta.env.VITE_API_BASE_URL as string) ??
-    window.location.origin + (window.CONTEXT_PATH || '') + '/db-scheduler-api';
+import { getApiBaseUrl } from './runtimeConfig';
 
-const config = await fetch(`${API_BASE_URL}/config`).then((res) =>
+const config = await fetch(`${getApiBaseUrl()}/config`).then((res) =>
   res.json(),
 );
 

--- a/db-scheduler-ui-frontend/src/utils/global.d.ts
+++ b/db-scheduler-ui-frontend/src/utils/global.d.ts
@@ -16,6 +16,16 @@ export {};
 declare global {
     interface Window {
         /** Path to prepended to API calls and the router basename (optional). */
-        CONTEXT_PATH: string;
+        CONTEXT_PATH?: string;
+        /** Frontend SPA path used when DB_SCHEDULER_UI is not injected. */
+        UI_PATH?: string;
+        /** API path used when DB_SCHEDULER_UI is not injected. */
+        API_PATH?: string;
+        DB_SCHEDULER_UI?: {
+            contextPath: string;
+            routePath?: string;
+            uiBasePath: string;
+            apiBasePath: string;
+        };
     }
 }

--- a/db-scheduler-ui-frontend/src/utils/runtimeConfig.ts
+++ b/db-scheduler-ui-frontend/src/utils/runtimeConfig.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const normalizePath = (path: string): string => {
+  const trimmedPath = path.trim();
+  const pathWithLeadingSlash = trimmedPath.startsWith('/')
+    ? trimmedPath
+    : `/${trimmedPath}`;
+  const normalized = pathWithLeadingSlash.replace(/\/+/g, '/').replace(/\/+$/, '');
+  return normalized || '/';
+};
+
+const joinPaths = (...paths: Array<string | undefined>): string =>
+  normalizePath(paths.filter((path): path is string => path !== undefined).join('/'));
+
+const isAbsoluteUrl = (url: string): boolean =>
+  /^[a-z][a-z\d+\-.]*:\/\//i.test(url);
+
+const trimTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
+
+const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL as
+  | string
+  | undefined;
+
+export const getUiBasePath = (): string =>
+  normalizePath(
+    window.DB_SCHEDULER_UI?.uiBasePath ??
+      joinPaths(window.CONTEXT_PATH, window.UI_PATH ?? import.meta.env.BASE_URL),
+  );
+
+export const getApiBaseUrl = (): string => {
+  if (configuredApiBaseUrl) {
+    return trimTrailingSlash(configuredApiBaseUrl);
+  }
+
+  const configuredApiBasePath = window.DB_SCHEDULER_UI?.apiBasePath;
+  if (configuredApiBasePath !== undefined) {
+    if (isAbsoluteUrl(configuredApiBasePath)) {
+      return trimTrailingSlash(configuredApiBasePath);
+    }
+
+    const apiBasePath = normalizePath(configuredApiBasePath);
+    return `${window.location.origin}${apiBasePath === '/' ? '' : apiBasePath}`;
+  }
+
+  if (window.API_PATH !== undefined && isAbsoluteUrl(window.API_PATH)) {
+    return trimTrailingSlash(window.API_PATH);
+  }
+
+  const apiBasePath = normalizePath(
+    joinPaths(window.CONTEXT_PATH, window.API_PATH ?? '/db-scheduler-api'),
+  );
+  return `${window.location.origin}${apiBasePath === '/' ? '' : apiBasePath}`;
+};
+
+export const redirectToUi = () => {
+  document.location.href = getUiBasePath();
+};

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/DbSchedulerUiPathEnvironmentPostProcessor.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/DbSchedulerUiPathEnvironmentPostProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.bekk.dbscheduler.uistarter.autoconfigure;
+
+import static no.bekk.dbscheduler.uistarter.config.DbSchedulerUiUtil.normalizePath;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+public class DbSchedulerUiPathEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+  private static final String PROPERTY_SOURCE_NAME = "dbSchedulerUiNormalizedPaths";
+  private static final String UI_PATH = "db-scheduler-ui.ui-path";
+  private static final String API_PATH = "db-scheduler-ui.api-path";
+
+  @Override
+  public void postProcessEnvironment(
+      ConfigurableEnvironment environment, SpringApplication application) {
+    Map<String, Object> normalizedPaths = new HashMap<>();
+    normalize(environment, normalizedPaths, UI_PATH);
+    normalize(environment, normalizedPaths, API_PATH);
+
+    if (!normalizedPaths.isEmpty()) {
+      environment
+          .getPropertySources()
+          .addFirst(new MapPropertySource(PROPERTY_SOURCE_NAME, normalizedPaths));
+    }
+  }
+
+  private static void normalize(
+      ConfigurableEnvironment environment, Map<String, Object> normalizedPaths, String property) {
+    if (!environment.containsProperty(property)) {
+      return;
+    }
+
+    String value = environment.getProperty(property);
+    String normalized = normalizePath(value);
+    if (!normalized.equals(value)) {
+      normalizedPaths.put(property, normalized);
+    }
+  }
+}

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -64,15 +64,21 @@ public class UiApiAutoConfiguration {
   private final String servletContextPath;
   private final String mvcServletPath;
   private final String dbSchedulerContextPath;
+  private final String uiPath;
+  private final String apiPath;
 
   UiApiAutoConfiguration(
       @Value("${server.servlet.context-path:}") String servletContextPath,
       @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
-      @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath) {
+      @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath,
+      @Value("${db-scheduler-ui.ui-path:/db-scheduler}") String uiPath,
+      @Value("${db-scheduler-ui.api-path:/db-scheduler-api}") String apiPath) {
     logger.info("UiApiAutoConfiguration created");
     this.servletContextPath = normalizePaths(servletContextPath);
     this.dbSchedulerContextPath = normalizePaths(dbSchedulerContextPath);
     this.mvcServletPath = normalizePaths(mvcServletPath);
+    this.uiPath = normalizePath(uiPath);
+    this.apiPath = normalizePath(apiPath);
   }
 
   @Bean
@@ -166,7 +172,7 @@ public class UiApiAutoConfiguration {
   SpaFallbackMvc spaFallbackMvc(
       @Value("${db-scheduler-ui.context-path:}") String contextPath,
       @Qualifier("indexHtml") String indexHtml) {
-    return new SpaFallbackMvc(normalizePath(contextPath), indexHtml);
+    return new SpaFallbackMvc(normalizePath(contextPath), uiPath, indexHtml);
   }
 
   @Bean
@@ -174,22 +180,29 @@ public class UiApiAutoConfiguration {
   @ConditionalOnMissingBean
   public RouterFunction<ServerResponse> dbSchedulerRouter(
       @Qualifier("indexHtml") String indexHtml) {
+    String pathPattern = uiPath.isEmpty() ? "/**" : uiPath + "/**";
     return RouterFunctions.route(
-        RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
+        RequestPredicates.GET(pathPattern).and(request -> !request.path().contains(".")),
         request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml));
   }
 
   @Bean
   @ConditionalOnMissingBean
   ConfigController configController(DbSchedulerUiProperties properties) {
-    return new ConfigController(properties.history(), properties.overview(), properties::readOnly);
+    return new ConfigController(
+        properties.history(), properties.overview(), properties::readOnly, uiPath, apiPath);
   }
 
   @Bean
   @ConditionalOnMissingBean
   IndexHtmlController indexHtmlController(
       @Qualifier("indexHtml") String indexHtml, @Qualifier("contextPath") String contextPath) {
-    return new IndexHtmlController(indexHtml, contextPath);
+    return new IndexHtmlController(
+        indexHtml,
+        contextPath,
+        uiPath,
+        normalizePaths(contextPath, uiPath),
+        normalizePaths(contextPath, apiPath));
   }
 
   @Bean
@@ -210,11 +223,12 @@ public class UiApiAutoConfiguration {
         new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE)
             .getContentAsString(StandardCharsets.UTF_8);
 
-    String contextPathScript = contextPath + "/db-scheduler/js/context-path.js";
+    String uiBasePath = normalizePaths(contextPath, uiPath);
+    String contextPathScript = normalizePaths(uiBasePath, "/js/context-path.js");
 
     return indexHtml
-        .replaceAll("/db-scheduler", contextPath + "/db-scheduler")
-        .replaceAll(
+        .replace("/db-scheduler", uiBasePath)
+        .replace(
             "<head>",
             """
       <head>

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
@@ -26,6 +26,8 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  * @param overview whether the UI exposes the task-centric overview page
  * @param logLimit cap on the number of history rows fetched per request; 0 applies no explicit
  *     {@code LIMIT} clause, but the result set is still capped at 500 rows by the query layer
+ * @param uiPath URL path for the frontend SPA, defaults to {@code /db-scheduler}
+ * @param apiPath URL path for the REST API endpoints, defaults to {@code /db-scheduler-api}
  */
 @ConfigurationProperties("db-scheduler-ui")
 public record DbSchedulerUiProperties(
@@ -34,4 +36,6 @@ public record DbSchedulerUiProperties(
     @DefaultValue("true") boolean taskData,
     @DefaultValue("false") boolean history,
     @DefaultValue("false") boolean overview,
-    @DefaultValue("0") int logLimit) {}
+    @DefaultValue("0") int logLimit,
+    @DefaultValue("/db-scheduler") String uiPath,
+    @DefaultValue("/db-scheduler-api") String apiPath) {}

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiUtil.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiUtil.java
@@ -28,8 +28,13 @@ public class DbSchedulerUiUtil {
       normalized = "/" + normalized;
     }
 
+    normalized = normalized.replaceAll("/+", "/");
+
     if (normalized.length() > 1 && normalized.endsWith("/")) {
       normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    if ("/".equals(normalized)) {
+      return "";
     }
     return normalized;
   }

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/PrefixedRequestMappingHandlerMapping.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/PrefixedRequestMappingHandlerMapping.java
@@ -34,7 +34,7 @@ public class PrefixedRequestMappingHandlerMapping extends RequestMappingHandlerM
     final Package aPackage = method.getDeclaringClass().getPackage();
     RequestMappingInfo finalMapping = mapping;
 
-    if (ConfigController.class.getPackage().equals(aPackage)) {
+    if (!prefix.isEmpty() && ConfigController.class.getPackage().equals(aPackage)) {
       finalMapping = RequestMappingInfo.paths(prefix).build().combine(mapping);
     }
     super.registerHandlerMethod(handler, method, finalMapping);

--- a/db-scheduler-ui-spring-boot-4-starter/src/main/resources/META-INF/spring.factories
+++ b/db-scheduler-ui-spring-boot-4-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.env.EnvironmentPostProcessor=\
-  no.bekk.dbscheduler.uistarter.autoconfigure.LegacyLogPropertyEnvironmentPostProcessor
+  no.bekk.dbscheduler.uistarter.autoconfigure.LegacyLogPropertyEnvironmentPostProcessor,\
+  no.bekk.dbscheduler.uistarter.autoconfigure.DbSchedulerUiPathEnvironmentPostProcessor

--- a/db-scheduler-ui-spring-boot-4-starter/src/test/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiUtilTest.java
+++ b/db-scheduler-ui-spring-boot-4-starter/src/test/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiUtilTest.java
@@ -37,6 +37,12 @@ class DbSchedulerUiUtilTest {
   }
 
   @Test
+  void testNormalizeRootPath() {
+    String path = DbSchedulerUiUtil.normalizePath("/");
+    assertThat(path).isEqualTo("");
+  }
+
+  @Test
   void testNormalizePaths() {
     String path = DbSchedulerUiUtil.normalizePaths("/api", "db-scheduler-ui");
     assertThat(path).isEqualTo("/api/db-scheduler-ui");
@@ -46,6 +52,12 @@ class DbSchedulerUiUtilTest {
   void testNormalizePathsExtraSlashes() {
     String path = DbSchedulerUiUtil.normalizePaths("/api/", "/db-scheduler-ui");
     assertThat(path).isEqualTo("/api/db-scheduler-ui");
+  }
+
+  @Test
+  void testNormalizePathsRootSegment() {
+    String path = DbSchedulerUiUtil.normalizePaths("/", "/db-scheduler-ui/");
+    assertThat(path).isEqualTo("/db-scheduler-ui");
   }
 
   @Test

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/DbSchedulerUiPathEnvironmentPostProcessor.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/DbSchedulerUiPathEnvironmentPostProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) Bekk
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.bekk.dbscheduler.uistarter.autoconfigure;
+
+import static no.bekk.dbscheduler.uistarter.config.DbSchedulerUiUtil.normalizePath;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+public class DbSchedulerUiPathEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+  private static final String PROPERTY_SOURCE_NAME = "dbSchedulerUiNormalizedPaths";
+  private static final String UI_PATH = "db-scheduler-ui.ui-path";
+  private static final String API_PATH = "db-scheduler-ui.api-path";
+
+  @Override
+  public void postProcessEnvironment(
+      ConfigurableEnvironment environment, SpringApplication application) {
+    Map<String, Object> normalizedPaths = new HashMap<>();
+    normalize(environment, normalizedPaths, UI_PATH);
+    normalize(environment, normalizedPaths, API_PATH);
+
+    if (!normalizedPaths.isEmpty()) {
+      environment
+          .getPropertySources()
+          .addFirst(new MapPropertySource(PROPERTY_SOURCE_NAME, normalizedPaths));
+    }
+  }
+
+  private static void normalize(
+      ConfigurableEnvironment environment, Map<String, Object> normalizedPaths, String property) {
+    if (!environment.containsProperty(property)) {
+      return;
+    }
+
+    String value = environment.getProperty(property);
+    String normalized = normalizePath(value);
+    if (!normalized.equals(value)) {
+      normalizedPaths.put(property, normalized);
+    }
+  }
+}

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/autoconfigure/UiApiAutoConfiguration.java
@@ -64,15 +64,21 @@ public class UiApiAutoConfiguration {
   private final String servletContextPath;
   private final String mvcServletPath;
   private final String dbSchedulerContextPath;
+  private final String uiPath;
+  private final String apiPath;
 
   UiApiAutoConfiguration(
       @Value("${server.servlet.context-path:}") String servletContextPath,
       @Value("${spring.mvc.servlet.path:}") String mvcServletPath,
-      @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath) {
+      @Value("${db-scheduler-ui.context-path:}") String dbSchedulerContextPath,
+      @Value("${db-scheduler-ui.ui-path:/db-scheduler}") String uiPath,
+      @Value("${db-scheduler-ui.api-path:/db-scheduler-api}") String apiPath) {
     logger.info("UiApiAutoConfiguration created");
     this.servletContextPath = normalizePaths(servletContextPath);
     this.dbSchedulerContextPath = normalizePaths(dbSchedulerContextPath);
     this.mvcServletPath = normalizePaths(mvcServletPath);
+    this.uiPath = normalizePath(uiPath);
+    this.apiPath = normalizePath(apiPath);
   }
 
   @Bean
@@ -166,7 +172,7 @@ public class UiApiAutoConfiguration {
   SpaFallbackMvc spaFallbackMvc(
       @Value("${db-scheduler-ui.context-path:}") String contextPath,
       @Qualifier("indexHtml") String indexHtml) {
-    return new SpaFallbackMvc(normalizePath(contextPath), indexHtml);
+    return new SpaFallbackMvc(normalizePath(contextPath), uiPath, indexHtml);
   }
 
   @Bean
@@ -174,22 +180,29 @@ public class UiApiAutoConfiguration {
   @ConditionalOnMissingBean
   public RouterFunction<ServerResponse> dbSchedulerRouter(
       @Qualifier("indexHtml") String indexHtml) {
+    String pathPattern = uiPath.isEmpty() ? "/**" : uiPath + "/**";
     return RouterFunctions.route(
-        RequestPredicates.GET("/db-scheduler/**").and(request -> !request.path().contains(".")),
+        RequestPredicates.GET(pathPattern).and(request -> !request.path().contains(".")),
         request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(indexHtml));
   }
 
   @Bean
   @ConditionalOnMissingBean
   ConfigController configController(DbSchedulerUiProperties properties) {
-    return new ConfigController(properties.history(), properties.overview(), properties::readOnly);
+    return new ConfigController(
+        properties.history(), properties.overview(), properties::readOnly, uiPath, apiPath);
   }
 
   @Bean
   @ConditionalOnMissingBean
   IndexHtmlController indexHtmlController(
       @Qualifier("indexHtml") String indexHtml, @Qualifier("contextPath") String contextPath) {
-    return new IndexHtmlController(indexHtml, contextPath);
+    return new IndexHtmlController(
+        indexHtml,
+        contextPath,
+        uiPath,
+        normalizePaths(contextPath, uiPath),
+        normalizePaths(contextPath, apiPath));
   }
 
   @Bean
@@ -210,11 +223,12 @@ public class UiApiAutoConfiguration {
         new ClassPathResource(SpaFallbackMvc.DEFAULT_STARTING_PAGE)
             .getContentAsString(StandardCharsets.UTF_8);
 
-    String contextPathScript = contextPath + "/db-scheduler/js/context-path.js";
+    String uiBasePath = normalizePaths(contextPath, uiPath);
+    String contextPathScript = normalizePaths(uiBasePath, "/js/context-path.js");
 
     return indexHtml
-        .replaceAll("/db-scheduler", contextPath + "/db-scheduler")
-        .replaceAll(
+        .replace("/db-scheduler", uiBasePath)
+        .replace(
             "<head>",
             """
       <head>

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiProperties.java
@@ -26,6 +26,8 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  * @param overview whether the UI exposes the task-centric overview page
  * @param logLimit cap on the number of history rows fetched per request; 0 applies no explicit
  *     {@code LIMIT} clause, but the result set is still capped at 500 rows by the query layer
+ * @param uiPath URL path for the frontend SPA, defaults to {@code /db-scheduler}
+ * @param apiPath URL path for the REST API endpoints, defaults to {@code /db-scheduler-api}
  */
 @ConfigurationProperties("db-scheduler-ui")
 public record DbSchedulerUiProperties(
@@ -34,4 +36,6 @@ public record DbSchedulerUiProperties(
     @DefaultValue("true") boolean taskData,
     @DefaultValue("false") boolean history,
     @DefaultValue("false") boolean overview,
-    @DefaultValue("0") int logLimit) {}
+    @DefaultValue("0") int logLimit,
+    @DefaultValue("/db-scheduler") String uiPath,
+    @DefaultValue("/db-scheduler-api") String apiPath) {}

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiUtil.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiUtil.java
@@ -28,8 +28,13 @@ public class DbSchedulerUiUtil {
       normalized = "/" + normalized;
     }
 
+    normalized = normalized.replaceAll("/+", "/");
+
     if (normalized.length() > 1 && normalized.endsWith("/")) {
       normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    if ("/".equals(normalized)) {
+      return "";
     }
     return normalized;
   }

--- a/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/PrefixedRequestMappingHandlerMapping.java
+++ b/db-scheduler-ui-starter/src/main/java/no/bekk/dbscheduler/uistarter/config/PrefixedRequestMappingHandlerMapping.java
@@ -34,7 +34,7 @@ public class PrefixedRequestMappingHandlerMapping extends RequestMappingHandlerM
     final Package aPackage = method.getDeclaringClass().getPackage();
     RequestMappingInfo finalMapping = mapping;
 
-    if (ConfigController.class.getPackage().equals(aPackage)) {
+    if (!prefix.isEmpty() && ConfigController.class.getPackage().equals(aPackage)) {
       finalMapping = RequestMappingInfo.paths(prefix).build().combine(mapping);
     }
     super.registerHandlerMethod(handler, method, finalMapping);

--- a/db-scheduler-ui-starter/src/main/resources/META-INF/spring.factories
+++ b/db-scheduler-ui-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.env.EnvironmentPostProcessor=\
-  no.bekk.dbscheduler.uistarter.autoconfigure.LegacyLogPropertyEnvironmentPostProcessor
+  no.bekk.dbscheduler.uistarter.autoconfigure.LegacyLogPropertyEnvironmentPostProcessor,\
+  no.bekk.dbscheduler.uistarter.autoconfigure.DbSchedulerUiPathEnvironmentPostProcessor

--- a/db-scheduler-ui-starter/src/test/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiUtilTest.java
+++ b/db-scheduler-ui-starter/src/test/java/no/bekk/dbscheduler/uistarter/config/DbSchedulerUiUtilTest.java
@@ -37,6 +37,12 @@ class DbSchedulerUiUtilTest {
   }
 
   @Test
+  void testNormalizeRootPath() {
+    String path = DbSchedulerUiUtil.normalizePath("/");
+    assertThat(path).isEqualTo("");
+  }
+
+  @Test
   void testNormalizePaths() {
     String path = DbSchedulerUiUtil.normalizePaths("/api", "db-scheduler-ui");
     assertThat(path).isEqualTo("/api/db-scheduler-ui");
@@ -46,6 +52,12 @@ class DbSchedulerUiUtilTest {
   void testNormalizePathsExtraSlashes() {
     String path = DbSchedulerUiUtil.normalizePaths("/api/", "/db-scheduler-ui");
     assertThat(path).isEqualTo("/api/db-scheduler-ui");
+  }
+
+  @Test
+  void testNormalizePathsRootSegment() {
+    String path = DbSchedulerUiUtil.normalizePaths("/", "/db-scheduler-ui/");
+    assertThat(path).isEqualTo("/db-scheduler-ui");
   }
 
   @Test

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/ConfigController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/ConfigController.java
@@ -15,6 +15,7 @@ package no.bekk.dbscheduler.ui.controller;
 
 import java.util.function.Supplier;
 import no.bekk.dbscheduler.ui.model.ConfigResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,21 +23,30 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @CrossOrigin
-@RequestMapping("/db-scheduler-api/config")
+@RequestMapping("${db-scheduler-ui.api-path:/db-scheduler-api}/config")
 public class ConfigController {
 
   private final boolean showHistory;
   private final boolean showOverview;
   private final Supplier<Boolean> readOnly;
+  private final String uiPath;
+  private final String apiPath;
 
-  public ConfigController(boolean showHistory, boolean showOverview, Supplier<Boolean> readOnly) {
+  public ConfigController(
+      boolean showHistory,
+      boolean showOverview,
+      Supplier<Boolean> readOnly,
+      @Value("${db-scheduler-ui.ui-path:/db-scheduler}") String uiPath,
+      @Value("${db-scheduler-ui.api-path:/db-scheduler-api}") String apiPath) {
     this.showHistory = showHistory;
     this.showOverview = showOverview;
     this.readOnly = readOnly;
+    this.uiPath = uiPath;
+    this.apiPath = apiPath;
   }
 
   @GetMapping
   public ConfigResponse getConfig() {
-    return new ConfigResponse(showHistory, showOverview, readOnly.get());
+    return new ConfigResponse(showHistory, showOverview, readOnly.get(), uiPath, apiPath);
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/IndexHtmlController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/IndexHtmlController.java
@@ -16,36 +16,67 @@ package no.bekk.dbscheduler.ui.controller;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("${db-scheduler-ui.ui-path:/db-scheduler}")
 public class IndexHtmlController {
 
   private final String patchedIndexHtml;
   private final String contextPath;
+  private final String routePath;
+  private final String uiBasePath;
+  private final String apiBasePath;
 
   public IndexHtmlController(
-      @Qualifier("indexHtml") String indexHtml, @Qualifier("contextPath") String contextPath) {
+      @Qualifier("indexHtml") String indexHtml,
+      @Qualifier("contextPath") String contextPath,
+      String routePath,
+      String uiBasePath,
+      String apiBasePath) {
     this.patchedIndexHtml = indexHtml;
     this.contextPath = contextPath;
+    this.routePath = routePath;
+    this.uiBasePath = uiBasePath;
+    this.apiBasePath = apiBasePath;
   }
 
   @GetMapping(
-      path = {
-        "/db-scheduler/index.html",
-        "/db-scheduler",
-        "/db-scheduler/history/all/index.html",
-        "/db-scheduler/history/all"
-      },
+      path = {"/index.html", "", "/history/all/index.html", "/history/all"},
       produces = MediaType.TEXT_HTML_VALUE)
   public String indexHtml() {
     return patchedIndexHtml;
   }
 
   @GetMapping(
-      path = {"/db-scheduler/js/context-path.js"},
+      path = {"/js/context-path.js"},
       produces = "text/javascript")
   public String contextPath() {
-    return "window.CONTEXT_PATH='" + contextPath + "';";
+    return "window.CONTEXT_PATH='"
+        + javaScriptString(contextPath)
+        + "';\n"
+        + "window.DB_SCHEDULER_UI = {\n"
+        + "  contextPath: '"
+        + javaScriptString(contextPath)
+        + "',\n"
+        + "  routePath: '"
+        + javaScriptString(routePath)
+        + "',\n"
+        + "  uiBasePath: '"
+        + javaScriptString(uiBasePath)
+        + "',\n"
+        + "  apiBasePath: '"
+        + javaScriptString(apiBasePath)
+        + "'\n"
+        + "};";
+  }
+
+  private static String javaScriptString(String value) {
+    return value
+        .replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r");
   }
 }

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/LogController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/LogController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @CrossOrigin
-@RequestMapping("/db-scheduler-api/logs")
+@RequestMapping("${db-scheduler-ui.api-path:/db-scheduler-api}/logs")
 public class LogController {
 
   private final LogLogic logLogic;

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/OverviewController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/OverviewController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @CrossOrigin
-@RequestMapping("/db-scheduler-api/tasks")
+@RequestMapping("${db-scheduler-ui.api-path:/db-scheduler-api}/tasks")
 public class OverviewController {
 
   private final OverviewService overviewService;

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/SpaFallbackMvc.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/SpaFallbackMvc.java
@@ -16,7 +16,6 @@ package no.bekk.dbscheduler.ui.controller;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import lombok.NonNull;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -28,18 +27,26 @@ public class SpaFallbackMvc implements WebMvcConfigurer {
   public static final String DEFAULT_STARTING_PAGE = "static/db-scheduler/index.html";
 
   private final String prefix;
+  private final String uiPath;
 
   private final String indexHtml;
 
-  public SpaFallbackMvc(@Value("${db-scheduler-ui.context-path}") String prefix, String indexHtml) {
+  public SpaFallbackMvc(String prefix, String uiPath, String indexHtml) {
     this.prefix = prefix;
+    this.uiPath = uiPath;
     this.indexHtml = indexHtml;
   }
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
+    String resourcePath = prefix + uiPath;
+    if (resourcePath.isEmpty()) {
+      resourcePath = "/";
+    }
+    String resourcePattern = "/".equals(resourcePath) ? "/**" : resourcePath + "/**";
+
     registry
-        .addResourceHandler(prefix + "/db-scheduler", prefix + "/db-scheduler/**")
+        .addResourceHandler(resourcePath, resourcePattern)
         .addResourceLocations("classpath:/static/db-scheduler/")
         .resourceChain(true)
         .addResolver(new SpaFallbackResolver(indexHtml));

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/TaskAdminController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/TaskAdminController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @CrossOrigin
-@RequestMapping("/db-scheduler-api/tasks")
+@RequestMapping("${db-scheduler-ui.api-path:/db-scheduler-api}/tasks")
 @ConditionalOnProperty(
     prefix = "db-scheduler-ui",
     name = "read-only",

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/TaskController.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/controller/TaskController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @CrossOrigin
-@RequestMapping("/db-scheduler-api/tasks")
+@RequestMapping("${db-scheduler-ui.api-path:/db-scheduler-api}/tasks")
 public class TaskController {
   private final TaskLogic taskLogic;
 

--- a/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/ConfigResponse.java
+++ b/db-scheduler-ui/src/main/java/no/bekk/dbscheduler/ui/model/ConfigResponse.java
@@ -24,4 +24,6 @@ public class ConfigResponse {
   private boolean showHistory;
   private boolean showOverview;
   private boolean readOnly;
+  private String uiPath;
+  private String apiPath;
 }

--- a/db-scheduler-ui/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/db-scheduler-ui/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -9,6 +9,18 @@
       "name": "db-scheduler-ui.overview",
       "type": "java.lang.Boolean",
       "description": "Expose the task-centric overview page in the UI."
+    },
+    {
+      "name": "db-scheduler-ui.ui-path",
+      "type": "java.lang.String",
+      "description": "UI path for the frontend SPA. Default is /db-scheduler.",
+      "defaultValue": "/db-scheduler"
+    },
+    {
+      "name": "db-scheduler-ui.api-path",
+      "type": "java.lang.String",
+      "description": "API path for REST endpoints. Default is /db-scheduler-api.",
+      "defaultValue": "/db-scheduler-api"
     }
   ]
 }

--- a/example-app-boot4/src/test/java/com/github/bekk/exampleapp/CustomPathsTest.java
+++ b/example-app-boot4/src/test/java/com/github/bekk/exampleapp/CustomPathsTest.java
@@ -1,0 +1,107 @@
+package com.github.bekk.exampleapp;
+
+import static com.github.bekk.exampleapp.tasks.OneTimeTaskExample.SEND_WELCOME_EMAIL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import no.bekk.dbscheduler.ui.model.ConfigResponse;
+import no.bekk.dbscheduler.ui.model.GetTasksResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@AutoConfigureTestRestTemplate
+@ActiveProfiles("custompaths")
+@SpringBootTest(
+    classes = {ExampleApp.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CustomPathsTest {
+
+  @LocalServerPort private Integer serverPort;
+
+  private String baseUrl;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @Test
+  void testTaskApiWithCustomPath() {
+    ResponseEntity<GetTasksResponse> result =
+        this.restTemplate.getForEntity(
+            baseUrl
+                + "/my-custom-api/tasks/all?filter=ALL&pageNumber=0&size=10&sorting=DEFAULT&asc=true&searchTerm="
+                + SEND_WELCOME_EMAIL.getTaskName(),
+            GetTasksResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).isNotNull();
+    assertThat(result.getBody().getItems()).isNotEmpty();
+    assertThat(result.getBody().getItems())
+        .anyMatch(taskModel -> taskModel.getTaskName().equals(SEND_WELCOME_EMAIL.getTaskName()));
+  }
+
+  @Test
+  void testDeleteTaskWithCustomPath() {
+    ResponseEntity<Void> result =
+        restTemplate.postForEntity(
+            baseUrl
+                + "/my-custom-api/tasks/delete?id=%s&name=%s"
+                    .formatted("delete-1", SEND_WELCOME_EMAIL.getTaskName()),
+            null,
+            Void.class);
+
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void testUiPageWithCustomPath() {
+    ResponseEntity<String> result =
+        this.restTemplate.getForEntity(baseUrl + "/my-custom-ui", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getHeaders().getContentType()).isNotNull();
+    assertThat(result.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_HTML)).isTrue();
+    assertThat(result.getBody()).contains("/my-custom-ui");
+  }
+
+  @Test
+  void testUnknownSpaRouteServesIndexHtml() {
+    ResponseEntity<String> result =
+        this.restTemplate.getForEntity(baseUrl + "/my-custom-ui/some-spa-route", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).contains("/my-custom-ui");
+    assertThat(result.getHeaders().getContentType()).isNotNull();
+    assertThat(result.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_HTML)).isTrue();
+  }
+
+  @Test
+  void testContextPathJsContainsCustomPaths() {
+    ResponseEntity<String> result =
+        this.restTemplate.getForEntity(baseUrl + "/my-custom-ui/js/context-path.js", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).contains("window.CONTEXT_PATH=");
+    assertThat(result.getBody()).contains("window.DB_SCHEDULER_UI = {");
+    assertThat(result.getBody()).contains("routePath: '/my-custom-ui'");
+    assertThat(result.getBody()).contains("uiBasePath: '/my-custom-ui'");
+    assertThat(result.getBody()).contains("apiBasePath: '/my-custom-api'");
+  }
+
+  @Test
+  void testConfigEndpointHasCustomPaths() {
+    ResponseEntity<ConfigResponse> result =
+        this.restTemplate.getForEntity(baseUrl + "/my-custom-api/config", ConfigResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).isNotNull();
+    assertThat(result.getBody().getUiPath()).isEqualTo("/my-custom-ui");
+    assertThat(result.getBody().getApiPath()).isEqualTo("/my-custom-api");
+  }
+
+  @BeforeEach
+  void setUp() {
+    baseUrl = "http://localhost:" + serverPort;
+  }
+}

--- a/example-app-boot4/src/test/resources/application-custompaths.properties
+++ b/example-app-boot4/src/test/resources/application-custompaths.properties
@@ -1,0 +1,3 @@
+spring.config.activate.on-profile=custompaths
+db-scheduler-ui.ui-path=my-custom-ui/
+db-scheduler-ui.api-path=my-custom-api/

--- a/example-app/src/test/java/com/github/bekk/exampleapp/CustomPathsTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/CustomPathsTest.java
@@ -1,0 +1,110 @@
+package com.github.bekk.exampleapp;
+
+import static com.github.bekk.exampleapp.tasks.OneTimeTaskExample.SEND_WELCOME_EMAIL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import no.bekk.dbscheduler.ui.model.ConfigResponse;
+import no.bekk.dbscheduler.ui.model.GetTasksResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("custompaths")
+@SpringBootTest(
+    classes = {ExampleApp.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration(
+    exclude = {SecurityAutoConfiguration.class, ManagementWebSecurityAutoConfiguration.class})
+class CustomPathsTest {
+
+  @LocalServerPort private Integer serverPort;
+
+  private String baseUrl;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @Test
+  void testTaskApiWithCustomPath() {
+    ResponseEntity<GetTasksResponse> result =
+        this.restTemplate.getForEntity(
+            baseUrl
+                + "/my-custom-api/tasks/all?filter=ALL&pageNumber=0&size=10&sorting=DEFAULT&asc=true&searchTerm="
+                + SEND_WELCOME_EMAIL.getTaskName(),
+            GetTasksResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).isNotNull();
+    assertThat(result.getBody().getItems()).isNotEmpty();
+    assertThat(result.getBody().getItems())
+        .anyMatch(taskModel -> taskModel.getTaskName().equals(SEND_WELCOME_EMAIL.getTaskName()));
+  }
+
+  @Test
+  void testDeleteTaskWithCustomPath() {
+    ResponseEntity<Void> result =
+        restTemplate.postForEntity(
+            baseUrl
+                + "/my-custom-api/tasks/delete?id=%s&name=%s"
+                    .formatted("delete-1", SEND_WELCOME_EMAIL.getTaskName()),
+            null,
+            Void.class);
+
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void testUiPageWithCustomPath() {
+    ResponseEntity<String> result =
+        this.restTemplate.getForEntity(baseUrl + "/my-custom-ui", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getHeaders().getContentType()).isNotNull();
+    assertThat(result.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_HTML)).isTrue();
+    assertThat(result.getBody()).contains("/my-custom-ui");
+  }
+
+  @Test
+  void testUnknownSpaRouteServesIndexHtml() {
+    ResponseEntity<String> result =
+        this.restTemplate.getForEntity(baseUrl + "/my-custom-ui/some-spa-route", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).contains("/my-custom-ui");
+    assertThat(result.getHeaders().getContentType()).isNotNull();
+    assertThat(result.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_HTML)).isTrue();
+  }
+
+  @Test
+  void testContextPathJsContainsCustomPaths() {
+    ResponseEntity<String> result =
+        this.restTemplate.getForEntity(baseUrl + "/my-custom-ui/js/context-path.js", String.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).contains("window.CONTEXT_PATH=");
+    assertThat(result.getBody()).contains("window.DB_SCHEDULER_UI = {");
+    assertThat(result.getBody()).contains("routePath: '/my-custom-ui'");
+    assertThat(result.getBody()).contains("uiBasePath: '/my-custom-ui'");
+    assertThat(result.getBody()).contains("apiBasePath: '/my-custom-api'");
+  }
+
+  @Test
+  void testConfigEndpointHasCustomPaths() {
+    ResponseEntity<ConfigResponse> result =
+        this.restTemplate.getForEntity(baseUrl + "/my-custom-api/config", ConfigResponse.class);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).isNotNull();
+    assertThat(result.getBody().getUiPath()).isEqualTo("/my-custom-ui");
+    assertThat(result.getBody().getApiPath()).isEqualTo("/my-custom-api");
+  }
+
+  @BeforeEach
+  void setUp() {
+    baseUrl = "http://localhost:" + serverPort;
+  }
+}

--- a/example-app/src/test/java/com/github/bekk/exampleapp/SmokeSpringSecurityTest.java
+++ b/example-app/src/test/java/com/github/bekk/exampleapp/SmokeSpringSecurityTest.java
@@ -106,7 +106,11 @@ class SmokeSpringSecurityTest {
     @Bean
     ConfigController configController(DbSchedulerUiProperties properties) {
       return new ConfigController(
-          properties.history(), properties.overview(), readOnly(properties));
+          properties.history(),
+          properties.overview(),
+          readOnly(properties),
+          "/db-scheduler",
+          "/db-scheduler-api");
     }
 
     private Supplier<Boolean> readOnly(DbSchedulerUiProperties properties) {

--- a/example-app/src/test/resources/application-custompaths.properties
+++ b/example-app/src/test/resources/application-custompaths.properties
@@ -1,0 +1,3 @@
+spring.config.activate.on-profile=custompaths
+db-scheduler-ui.ui-path=my-custom-ui/
+db-scheduler-ui.api-path=my-custom-api/


### PR DESCRIPTION
## Summary

This was on my list to improve the UI package, finally was able to send a PR.

Adds support for serving db-scheduler-ui from configurable UI and API base paths, so the bundled frontend can work behind arbitrary context paths and in non-Spring hosts such as Ktor.

## Changes

- Added runtime frontend path resolution via `window.DB_SCHEDULER_UI`, `CONTEXT_PATH`, `UI_PATH`, `API_PATH`, and `VITE_API_BASE_URL`.
- Added `db-scheduler-ui.ui-path` and `db-scheduler-ui.api-path` support for Spring Boot 3 and Boot 4 starters.
- Normalized configured paths to handle missing leading slashes, trailing slashes, duplicate slashes, and root paths.
- Injected runtime UI/API path config into the SPA shell.
- Updated API calls and unauthorized redirects to use runtime paths.
- Encoded POST query parameters for task delete/run-group actions.
- Added custom-path integration tests for Boot 3 and Boot 4.

 This was also requested in ktor: https://github.com/osoykan/db-scheduler-additions/issues/100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable UI and API base paths, allowing deployments to use custom URLs instead of fixed defaults.
  * The app now exposes these path settings in its configuration response and client-side bootstrap data.

* **Bug Fixes**
  * Improved handling of URL paths so custom routes and fallback navigation work reliably.
  * Unauthorized responses now redirect users back to the UI consistently across screens and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->